### PR TITLE
Fix path for Ubuntu upstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ env NODE_ENV=production
 env LOGSENE_TOKEN=YOUR_LOGSENE_TOKEN
 chdir  /var/log
 
-exec /usr/local/bin/logagent -s /var/log/*.log 
+exec /usr/bin/logagent -s /var/log/*.log 
 ```
 
 Start the service: 


### PR DESCRIPTION
Following the instructions, it installs in /usr/bin and not in /usr/local/bin