### PR TITLE
fixed a typo in patterns.yml

### DIFF
--- a/patterns.yml
+++ b/patterns.yml
@@ -38,7 +38,7 @@ globalTransform: !!js/function >
 
 patterns:
  - # kubernetes hyperkube
-  sourcName: !!js/regexp /hyperkube/
+  sourceName: !!js/regexp /hyperkube/
   match:
     - type: hyperkube
       regex: !!js/regexp /\S+\s(\S+)\s+\S+\s+\S+\s([GET|POST|PUT|DELETE|HEAD|OPTIONS]+)\s+(\/.+)\:\s\(([\d|\.]+)(\S+)\)\s(\d+\s)(.*hyperkube.+)\s(.+)\:(\d+)\]/i


### PR DESCRIPTION
There was a typo in the `sourceName` field for kubernetes hyperkube pattern specification.
Actually, I came here from logagent article on sematext and I'm not really using this project, so feel free to correct me if I have done anything wrong.

