### PR TITLE
Fixed originalLine typo

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -156,7 +156,7 @@ function getLoggerForToken (token, type) {
           app: data.app,
           host: data.host,
           process_type: data.process_type,
-          originalLine: data.origignalLine,
+          originalLine: data.originalLine,
           severity: data.severity,
           facility: data.facility
         }


### PR DESCRIPTION
This was preventing the "originalLine" field from showing up