### PR TITLE
Fix typos that break GeoIP enriching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ LogParser.prototype = {
         var cbInitGeoIp = null
         try {
           try {
-            fs.statsSync(fileName)
+            fs.statSync(fileName)
             geoip = require('maxmind')
             initGeoIp.bind(this)(null, fileName)
             cbInitGeoIp = null
@@ -297,7 +297,7 @@ LogParser.prototype = {
             console.log('Error in' + p.type + '.filter():' + ex)
           }
         }
-        this.enrichGeoIp(p, p.geoIP)
+        this.enrichGeoIp(parsed, p.geoIP)
         // remove ts field, because Elasticsearch
         // might have problems to index it
         // it could be recognized as string or data


### PR DESCRIPTION
There are two issues here, one in the call of fs.statSync() and one where the "p" object (metadata) is parsed instead of "parsed" (with the actual data).