### PR TITLE
fix undefined sourceName when using command input

### DIFF
--- a/lib/plugins/input/command.js
+++ b/lib/plugins/input/command.js
@@ -9,7 +9,7 @@ function InputCommand (config, eventEmitter) {
 InputCommand.prototype.start = function () {
   if (!this.started) {
     this.started = true
-    this.runCommand(this.config.command, {source: this.config.sourceName || this.config.command})
+    this.runCommand(this.config.command, {sourceName: this.config.sourceName || this.config.command})
   }
 }
 


### PR DESCRIPTION
When using the command input, the `sourceName` config item doesn't have any effect because it's used to populate `source` in the context rather than `sourceName`.  This causes the `sourceName` parameter to be `undefined` in the json parser transform function.