### PR TITLE
Bunyan log parsing

### DIFF
--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -417,10 +417,11 @@ LogParser.prototype = {
         parsed.message = parsed.msg
         delete parsed.msg
         parsed['@timestamp'] = new Date(parsed.time)
+        delete parsed.time
         parsed.level = String(parsed.level)
         parsed.severity = bunyanLogLevels[parsed.level] || 'info'
       }
-      if (this.cfg.json != undefined && this.cfg.json.transform != undefined) {
+      if (this.cfg.json !== undefined && this.cfg.json.transform !== undefined) {
         this.cfg.json.transform.call(null, source, parsed, this.cfg.json)
       }
       // TODO JSON GeoIP enrichment

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,9 @@
 process.env.GEOIP_ENABLED = 'true'
 var util = require('util')
+var Logagent = require('../lib/parser/parser.js')
 describe('Logagent parse JSON', function () {
-  it('should return corect message with timestamp', function (done) {
+  it('should return correct message with timestamp', function (done) {
     this.timeout(150000)
-    var Logagent = require('../lib/parser/parser.js')
     var la = new Logagent()
     la.parseLine(JSON.stringify({
       message: 'hello world',
@@ -22,11 +22,34 @@ describe('Logagent parse JSON', function () {
   })
 })
 
+describe('Logagent parse bunyan JSON', function () {
+  it('should return correct message with timestamp', function (done) {
+    this.timeout(150000)
+    var la = new Logagent()
+    la.parseLine(JSON.stringify({
+      pid: 6023,
+      level: 30,
+      msg: 'hello world',
+      time: '2017-02-08T21:13:49.515Z',
+      v: 0,
+      counter: 1
+    }), 'json', function (err, data) {
+      if (err) {
+        done(err)
+      } else {
+        if (data.message === 'hello world' && data.counter === 1 && data['@timestamp']) {
+          done()
+        } else {
+          done(new Error('message is wrong: ' + data.message))
+        }
+      }
+    })
+  })
+})
+
 describe('Logagent parse web server Log', function () {
   it('should return client_ip, status_code, geo ip location', function (done) {
     this.timeout(150000)
-
-    var Logagent = require('../lib/parser/parser.js')
     var la = new Logagent(null, null, function ready (laReady) {
       // console.log('ready', arguments)
       laReady.parseLine('91.67.80.14 - - [03/Apr/2016:06:25:38 +0000] "GET /about/ HTTP/1.1" 200 14243 "https://sematext.com/consulting/elasticsearch/" "Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B436 Twitter for iPhone"',
@@ -51,7 +74,6 @@ describe('Logagent parse web server Log', function () {
 describe('Logagent parse unknown log', function () {
   it('should have message===logtext and timestamp', function (done) {
     this.timeout(150000)
-    var Logagent = require('../lib/parser/parser.js')
     var la = new Logagent()
     var logText = 'a simple log line matching no patterns'
     la.parseLine(logText,


### PR DESCRIPTION
The current [bunyan log version is 0](https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L18) which means that the current test for bunyan log format doesn't work as `parsed.v` won't be truthy.

This patch fixes that issue, adds code to remove the bunyan `time` field after converting it to `@timestamp`, and adds a test for proper bunyan message parsing.