### PR TITLE
Add support for time-based index patterns, prefer severity over level

### DIFF
--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -19,9 +19,7 @@ function OutputElasticsearch (config, eventEmitter) {
   this.loggers = {}
   this.laStats = require('../../core/printStats')
   if (config.indices) {
-    if (config.indices) {
-      config.tokenMapper = new LogSourceToIndexMapper(config.indices)
-    }
+    config.tokenMapper = new LogSourceToIndexMapper(config.indices)
   }
   if (this.config.url) {
     this.config.elasticsearchUrl = config.url
@@ -55,7 +53,7 @@ function OutputElasticsearch (config, eventEmitter) {
 OutputElasticsearch.prototype.indexData = function (token, logType, data) {
   var logger = this.getLogger(token, logType)
   this.logCount++
-  logger.log(data.level || data.severity || 'info', data.message || data.msg || data.MESSAGE, data)
+  logger.log(data.severity || data.level || 'info', data.message || data.msg || data.MESSAGE, data)
 }
 
 OutputElasticsearch.prototype.getLogger = function (token, type) {
@@ -96,15 +94,28 @@ OutputElasticsearch.prototype.getLogger = function (token, type) {
 OutputElasticsearch.prototype.eventHandler = function (data, context) {
   var index = context.index || this.config.index || process.env.LOGSENE_TOKEN
   if (this.config.tokenMapper) {
-    var indexForSource = this.config.tokenMapper.findToken([data.logSource || context.sourceName]) || index
-    if (indexForSource) {
-      this.indexData(indexForSource, data['_type'] || 'logs', data)
-    }
-  } else {
-    if (index) {
-      this.indexData(index, data['_type'] || 'logs', data)
-    }
+    index = this.config.tokenMapper.findToken([data.logSource || context.sourceName]) || index
   }
+
+  if (!index) {
+    return
+  }
+
+  // support for time-based index patterns
+  index = index.replace(/YYYY|MM|DD/g, function (match) {
+    if (match === 'YYYY') {
+      return '' + data['@timestamp'].getFullYear()
+    }
+    if (match === 'MM') {
+      return ('0' + (data['@timestamp'].getMonth() + 1)).substr(-2)
+    }
+    if (match === 'DD') {
+      return ('0' + data['@timestamp'].getDate()).substr(-2)
+    }
+    return match
+  })
+
+  this.indexData(index, data['_type'] || 'logs', data)
 }
 
 OutputElasticsearch.prototype.start = function () {
@@ -118,7 +129,7 @@ OutputElasticsearch.prototype.stop = function (cb) {
   var self = this
   process.nextTick(function () {
     var count = Object.keys(this.loggers).length - 1
-    Object.keys(this.loggers).forEach(function (l, i) {
+    Object.keys(this.loggers).forEach(function (l) {
       consoleLogger.log('send ' + l)
       this.loggers[l].send()
       this.loggers[l].on('log', function (evt) {


### PR DESCRIPTION
This patch adds support for replacing `YYYY`, `MM` & `DD` in target index names with the full year, month & date respectively.  With this patch a user can specify an index like `logstash-YYYY.MM.DD` to duplicate the behavior of logstash's default index pattern.

This patch also tweaks the preference order for the `Logsene.log` `level` parameter (which is actually used to populate `severity`) to prefer `severity` over `level`.

Finally, it removes an unneeded `if` statement and an unneeded variable `i`.