### PR TITLE
Fix initial maxmind update

### DIFF
--- a/lib/parser/maxmind-update.js
+++ b/lib/parser/maxmind-update.js
@@ -29,9 +29,9 @@ module.exports = function updateMaxmind (debug, maxmindDbDir, cb) {
     process.env.MAXMIND_DB_DIR = process.env.MAXMIND_DB_DIR || path.join(os.tmpdir(), '/')
   }
   if (debug) {
-    console.log('update maxmind db ' + process.env.MAXMIND_DB_DIR + 'GeoIPCity.dat')
+    console.log('update maxmind db ' + process.env.MAXMIND_DB_DIR + 'GeoLite2-City.mmdb')
   }
-  var fileName = path.join(process.env.MAXMIND_DB_DIR, 'GeoIPCity.dat')
+  var fileName = path.join(process.env.MAXMIND_DB_DIR, 'GeoLite2-City.mmdb')
   if (init === false && require('child_process').execSync) {
     init = true
     try {
@@ -61,7 +61,7 @@ module.exports = function updateMaxmind (debug, maxmindDbDir, cb) {
           console.log(stdout)
         }
         if (!err && !init && cb !== null) {
-          cb(null, path.join(process.env.MAXMIND_DB_DIR, 'GeoIPCity.dat'))
+          cb(null, path.join(process.env.MAXMIND_DB_DIR, 'GeoLite2-City.mmdb'))
           init = true
         }
       })

--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -107,8 +107,8 @@ LogParser.prototype = {
       var cbInitGeoIp = null
       try {
         try {
-          fs.statSync(fileName)
           geoip = require('maxmind')
+          fs.statSync(fileName)
           initGeoIp.bind(this)(null, fileName)
           cbInitGeoIp = null
         } catch (fsStatsErr) {


### PR DESCRIPTION
Initial maxmind update was failing because of wrong filename, probably introduced by commit 44c7c8eba796ee96e18fdf5687373370ffc73d2e

Also had to move require of maxmind up before trying to stat the file, otherwise it was null when callback was called later.