### PR TITLE
Change output plugin bind `eventHandler` in the constructor

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -127,6 +127,7 @@ var safeStringify = require('fast-safe-stringify')
 function OutputStdout (config, eventEmitter) {
   this.config = config
   this.eventEmitter = eventEmitter
+  this.eventHandler = this.eventHandler.bind(this);
 }
 
 OutputStdout.prototype.eventHandler = function (data, context) {
@@ -143,7 +144,7 @@ OutputStdout.prototype.eventHandler = function (data, context) {
 }
 
 OutputStdout.prototype.start = function () {
-  this.eventEmitter.on('data.parsed', this.eventHandler.bind(this))
+  this.eventEmitter.on('data.parsed', this.eventHandler)
 }
 
 OutputStdout.prototype.stop = function (cb) {


### PR DESCRIPTION
If the `eventHandler` is bound in the start method than it is not possible to remove the listener later on and
the stop function will not work as expected