### PR TITLE
Prevent startup crash while using gelf input

### DIFF
--- a/lib/plugins/input/gelf.js
+++ b/lib/plugins/input/gelf.js
@@ -26,11 +26,11 @@ InputGELF.prototype.stop = function (cb) {
 }
 
 InputGELF.prototype.createServer = function () {
-  var self = this
+  var self = this;
   this.server = gelfserver();
   this.server.on('message', function (gelf) {
     //At the moment gelf server doesn't expose rinfo
-    self.eventEmitter.emit('data.raw', safeStringify(gelf), {sourceName: 'input-gelf ',source: this.config.bindAddress })
+    self.eventEmitter.emit('data.raw', safeStringify(gelf), {sourceName: 'input-gelf ',source: self.config.bindAddress })
   })  
   this.server.listen(this.config.port ,this.config.bindAddress)
 }


### PR DESCRIPTION
`this` is the wrong context object inside of that function, changing to `self` has the desired effect.