### PR TITLE
Add output prometheus-alertmanager

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -61,6 +61,7 @@ var moduleAlias = {
   // output plugins
   'elasticsearch': '../lib/plugins/output/elasticsearch.js',
   'slack-webhook': '../lib/plugins/output/slack-webhook.js',
+  'prometheus-alertmanager': '../lib/plugins/output/prometheus-alertmanager.js',
   'output-kafka': 'logagent-output-kafka',
   'output-files': '../lib/plugins/output/files.js',
   'output-gelf': '../lib/plugins/output/gelfout.js',

--- a/config/examples/elasticsearch-query-input_prometheus-alertmanager-output.yml
+++ b/config/examples/elasticsearch-query-input_prometheus-alertmanager-output.yml
@@ -1,0 +1,43 @@
+# optional credentials for Amazon Elasticsearch
+# aws:
+#   auth: 'username:password'
+#   awsConfigFile: ./aws-config.json
+
+input:
+  queryLogs: 
+    # set to true for Amazon Elasticsearch service
+    awsEnabled: false
+    module: elasticsearch-query
+    sourceName: errorQuery
+    # repeat query every N seconds
+    interval: 60
+    log: 'error'
+    url: http://elasticsearch/
+    query: 
+      size: 50
+      index: logs-*app-proxy*
+      body:
+        query:
+          bool:
+            must: 
+              - query_string:
+                  query: '*foo122*'
+            filter:
+              - range:
+                  '@timestamp':
+                    gte: now-3600m/m
+                    lte: now/m
+
+output:
+  # stdout: yaml 
+  prometheus:
+    module: prometheus-alertmanager
+    url: http://localhost:9093
+    alertTemplate:
+      generatorURL: http://kibana/_plugin/kibana/app/kibana#/discover?&_a=(query:(language:lucene,query:'*{host}*'))
+      labels:
+        host: "{host}"
+        environment: "{environment}"
+      annotations:
+        environment: "{environment}"
+    debug: true

--- a/lib/plugins/output/prometheus-alertmanager.js
+++ b/lib/plugins/output/prometheus-alertmanager.js
@@ -73,7 +73,7 @@ OutputPrometheusAlertmanager.prototype.eventHandler = function (data, context) {
   request.post(options, function responseHandler (error, response, body) {
     if (!error && response.statusCode < 300) {
       if (this.debug === true) {
-        console.error(new Date(), 'Alert sent to Prometheus Alertmanager sent: alert=' + JSON.stringify(this.alert), body)
+        console.error(new Date(), 'Alert sent to Prometheus Alertmanager: alert=' + JSON.stringify(this.alert), body)
       }
     } else {
       console.error(new Date(), 'Error while alerting Prometheus Alertmanager:', error, body)

--- a/lib/plugins/output/prometheus-alertmanager.js
+++ b/lib/plugins/output/prometheus-alertmanager.js
@@ -1,0 +1,84 @@
+'use strict'
+var format = require('string-template')
+var request = require('request')
+function OutputPrometheusAlertmanager (config, eventEmitter) {
+  if (!config || !config.url) {
+    throw new TypeError('Please specify Prometheus Alertmanager "url"')
+  }
+  this.config = config
+  this.eventEmitter = eventEmitter
+}
+
+/* see https://prometheus.io/docs/alerting/clients/
+/* payload:
+[
+  {
+    "labels": {
+      "<labelname>": "<labelvalue>",
+      ...
+    },
+    "annotations": {
+      "<labelname>": "<labelvalue>",
+    },
+    "startsAt": "<rfc3339>",
+    "endsAt": "<rfc3339>",
+    "generatorURL": "<generator_url>"
+  },
+  ...
+]
+*/
+OutputPrometheusAlertmanager.prototype.buildAlert = function (data, context) {
+  var alert = {
+    "labels": {},
+    "annotations": {}
+  }
+  if (this.config.alertTemplate) {
+    if (this.config.alertTemplate.generatorURL) {
+      alert.generatorURL = format(this.config.alertTemplate.generatorURL, data)
+    }
+    var labels = Object.keys(this.config.alertTemplate.labels || {});
+    for (var i = 0; i < labels.length; i++) {
+      var label = labels[i]
+      alert.labels[label] = format(this.config.alertTemplate.labels[label], data)
+    }
+    var annotations = Object.keys(this.config.alertTemplate.annotations || {});
+    for (var i = 0; i < annotations.length; i++) {
+      var label = annotations[i]
+      alert.annotations[label] = format(this.config.alertTemplate.annotations[label], data)
+    }
+  }
+  return alert
+}
+
+OutputPrometheusAlertmanager.prototype.eventHandler = function (data, context) {
+  var alert = this.buildAlert(data, context)
+  var options = {
+    url: this.config.url + '/api/v1/alerts',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    json: [
+      alert
+    ]
+  }
+  request.post(options, function responseHandler (error, response, body) {
+    if (!error && response.statusCode < 300) {
+      if (this.debug === true) {
+        console.error(new Date(), 'Alert sent to Prometheus Alertmanager sent: alert=' + JSON.stringify(this.alert), body)
+      }
+    } else {
+      console.error(new Date(), 'Error while alerting Prometheus Alertmanager:', error, body)
+    }
+  }.bind({debug: this.config.debug, alert: alert}))
+}
+
+OutputPrometheusAlertmanager.prototype.start = function () {
+  this.eventEmitter.on('data.parsed', this.eventHandler.bind(this))
+}
+
+OutputPrometheusAlertmanager.prototype.stop = function (cb) {
+  this.eventEmitter.removeListener('data.parsed', this.eventHandler)
+  cb()
+}
+
+module.exports = OutputPrometheusAlertmanager

--- a/lib/plugins/output/prometheus-alertmanager.js
+++ b/lib/plugins/output/prometheus-alertmanager.js
@@ -1,6 +1,15 @@
 'use strict'
 var format = require('string-template')
-var request = require('request')
+var request
+try {
+  request = require('request')
+} catch (e) {
+  request = {
+    post: function() {
+      require('request')
+    }
+  }
+}
 function OutputPrometheusAlertmanager (config, eventEmitter) {
   if (!config || !config.url) {
     throw new TypeError('Please specify Prometheus Alertmanager "url"')

--- a/test/output-prometheus-alertmanager-test.js
+++ b/test/output-prometheus-alertmanager-test.js
@@ -1,0 +1,64 @@
+var assert = require('assert')
+var OutputPrometheusAlertmanager = require('../lib/plugins/output/prometheus-alertmanager.js')
+describe('OutputPrometheusAlertmanager', function () {
+  describe('#new', function () {
+    it('throws if no config given', function () {
+      assert.throws(function() {
+        new OutputPrometheusAlertmanager({})
+      }, {
+        name: 'TypeError',
+        message: 'Please specify Prometheus Alertmanager "url"'
+      })
+    })
+
+    it('throws if no config.url given', function () {
+      assert.throws(function() {
+        new OutputPrometheusAlertmanager()
+      }, {
+        name: 'TypeError',
+        message: 'Please specify Prometheus Alertmanager "url"'
+      })
+    })
+
+    it('returns instance', function () {
+      new OutputPrometheusAlertmanager({url: 'foo'})
+    })
+  })
+
+  describe('#buildAlert', function () {
+    it('return alert', function () {
+      var output = new OutputPrometheusAlertmanager({url: 'foo'})
+      assert.deepEqual(output.buildAlert(), {
+        labels: {},
+        annotations: {}
+      })
+    })
+
+    it('return alert with templated values', function () {
+      var output = new OutputPrometheusAlertmanager({
+        url: 'foo',
+        alertTemplate: {
+          generatorURL: 'http://foo?myVarA={myVarA}&myVarB={myVarB}',
+          labels: {
+            myLabel: '{myVarA}-{myVarB}'
+          },
+          annotations: {
+            myAnnotation: '{myVarA} and {myVarB}'
+          }
+        }
+      })
+      assert.deepEqual(output.buildAlert({
+        myVarA: 'valOfMyVarA',
+        myVarB: 'valOfMyVarB'
+      }), {
+        generatorURL: 'http://foo?myVarA=valOfMyVarA&myVarB=valOfMyVarB',
+        labels: {
+          myLabel: 'valOfMyVarA-valOfMyVarB'
+        },
+        annotations: {
+          myAnnotation: 'valOfMyVarA and valOfMyVarB'
+        }
+      })
+    })
+  })
+})

--- a/test/output-prometheus-alertmanager-test.js
+++ b/test/output-prometheus-alertmanager-test.js
@@ -5,19 +5,13 @@ describe('OutputPrometheusAlertmanager', function () {
     it('throws if no config given', function () {
       assert.throws(function() {
         new OutputPrometheusAlertmanager({})
-      }, {
-        name: 'TypeError',
-        message: 'Please specify Prometheus Alertmanager "url"'
-      })
+      }, /Please specify Prometheus Alertmanager "url"/)
     })
 
     it('throws if no config.url given', function () {
       assert.throws(function() {
         new OutputPrometheusAlertmanager()
-      }, {
-        name: 'TypeError',
-        message: 'Please specify Prometheus Alertmanager "url"'
-      })
+      }, /Please specify Prometheus Alertmanager "url"/)
     })
 
     it('returns instance', function () {


### PR DESCRIPTION
This adds a output plugin that allows to use query results from elasticsearch, transform and send them as to prometheus alertmanager API.

That way one can re-use existing prometheus alertmanager infrastructure that has lots of alert providers (email, slack, pagerduty, ...).

Note: prometheus alertmanager automatically starts alerts and deduplicates them when sent again. Alerts are closed after defined timeout time (configured in alertmanager).

See https://prometheus.io/docs/alerting/clients/