### PR TITLE
self.terminate() on uncaught exceptions

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -388,7 +388,6 @@ LaCli.prototype.initState = function () {
   process.once('SIGTERM', function () { self.terminate('SIGTERM') })
   process.once('beforeExit', self.terminate)
   process.once('uncaughtException', function (error) { self.terminate(error.message) })
-  process.once('unhandledRejection', function (reason) { self.terminate(reason) })
 }
 
 LaCli.prototype.log = function (err, data) {

--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-process.on('unhandledRejection', (p, reason) => {
+process.on('unhandledRejection', (reason, p) => {
   console.log('Possibly Unhandled Rejection at: Promise ', p, 'reason: ', reason)
 })
 var consoleLogger = require('../lib/util/logger.js')
@@ -387,6 +387,8 @@ LaCli.prototype.initState = function () {
   process.once('SIGQUIT', function () { self.terminate('SIGQUIT') })
   process.once('SIGTERM', function () { self.terminate('SIGTERM') })
   process.once('beforeExit', self.terminate)
+  process.once('uncaughtException', function (error) { self.terminate(error.message) })
+  process.once('unhandledRejection', function (reason) { self.terminate(reason) })
 }
 
 LaCli.prototype.log = function (err, data) {


### PR DESCRIPTION
## Goal
This PR ensure that the app properly cleans up after itself (connections closed, file handles terminated, store last file positions) in crash conditions. The use case that led to this PR was noticing that logagentTailPointers.json wasn't being created/updated in case of a plugin throwing an uncaught exception. Obviously, one could ask "why is a plugin throwing an uncaught exception?", but I think that's a much bigger problem.

## Approach
Added uncaughtException to the set of events that trigger a call to self.terminate()