### PR TITLE
add support for `fatal error` pattern

### DIFF
--- a/patterns.yml
+++ b/patterns.yml
@@ -91,7 +91,7 @@ json:
 patterns:
  - # sematext/agent logs 
   sourceName: !!js/regexp /sematext\/agent/
-  blockStart: !!js/regexp /^panic\:|^unexpected fault address|(^INFO|^ERRO|^WARN|^FAT|^TRAC|^DEB)|^time=|^S{2,}/
+  blockStart: !!js/regexp /^panic\:|^unexpected fault address|^fatal error\:|(^INFO|^ERRO|^WARN|^FAT|^TRAC|^DEB)|^time=|^S{2,}/
   match:
     - type: sematext_agent_golang
       regex: !!js/regexp /time=(\S+)\slevel=(\S+?)\smsg="(.+?)"\ssource="(.+?)"/i


### PR DESCRIPTION
For certain panic errors, the line starts with `fatal error:` (e.g. `fatal error: concurrent map iteration and map write`)