### PR TITLE
Convert all values to strings when creating error messages

### DIFF
--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -7,7 +7,7 @@ var reduceConfig = require('../../util/config-reducer.js')
 function formatObject (o) {
   var rv = ''
   Object.keys(o).forEach(function (key) {
-    rv = rv + ' ' + key + '=' + o[key]
+    rv = rv + ' ' + key + '=' + JSON.stringify(o[key])
   })
   return rv
 }


### PR DESCRIPTION
Some of the 'error' events emitted by `logsene-js` contain nested objects. This would cause messages to contain '[Object object]' strings instead of the expected object, which can sometimes be useful to understand the error.