### PR TITLE
Use Kubernetes annotations

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -71,7 +71,7 @@ var moduleAlias = {
   'remove-fields': '../lib/plugins/output-filter/remove-fields.js',
   'drop-events': '../lib/plugins/output-filter/dropEventsFilter.js',
   'docker-enrichment': '../lib/plugins/output-filter/docker-log-enrichment.js',
-  'k8s-enrichment': '../lib/plugins/output-filter/kubernetes-enrichment.js',
+  'kubernetes-enrichment': '../lib/plugins/output-filter/kubernetes-enrichment.js',
   // output plugins
   'elasticsearch': '../lib/plugins/output/elasticsearch.js',
   'slack-webhook': '../lib/plugins/output/slack-webhook.js',
@@ -343,7 +343,7 @@ LaCli.prototype.loadPlugins = function (configFile) {
   }
   if (this.argv.k8sEnrichment) {
     outputFilter.push({
-      module: 'k8s-enrichment'
+      module: 'kubernetes-enrichment'
     })
   }
   if (configFile && configFile.outputFilter) {

--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -71,6 +71,7 @@ var moduleAlias = {
   'remove-fields': '../lib/plugins/output-filter/remove-fields.js',
   'drop-events': '../lib/plugins/output-filter/dropEventsFilter.js',
   'docker-enrichment': '../lib/plugins/output-filter/docker-log-enrichment.js',
+  'k8s-enrichment': '../lib/plugins/output-filter/kubernetes-enrichment.js',
   // output plugins
   'elasticsearch': '../lib/plugins/output/elasticsearch.js',
   'slack-webhook': '../lib/plugins/output/slack-webhook.js',

--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -341,6 +341,11 @@ LaCli.prototype.loadPlugins = function (configFile) {
       autodetectSeverity: true
     })
   }
+  if (this.argv.k8sEnrichment) {
+    outputFilter.push({
+      module: 'k8s-enrichment'
+    })
+  }
   if (configFile && configFile.outputFilter) {
     var outputFilterSections = Object.keys(configFile.outputFilter)
     outputFilterSections.forEach(function (key) {

--- a/config/example.yml
+++ b/config/example.yml
@@ -614,6 +614,24 @@ outputFilter:
 ##########################################
 
 ##########################################
+# KUBERNETES ENRICHMENT
+# Output filter plugin to add metadata from Kubernetes API 
+# Annotations can be used to route logs to different Sematext Log Apps by setting  
+# sematext.com/logs-token=YOUR_LOGS_TOKEN_HERE, disable logs from a pod or remove some log fields.
+# The plugin interprets the following pod annoations: 
+#   sematext.com/logs-token=YOUR_LOGS_TOKEN_HERE,     # set an individaul logs token for a pod
+#   sematext.com/logs-enabled=false                   # disable logs of a pod, 
+#   sematext.com/logs-remove-fields=labels,logSource  # remove fields from logs 
+#
+##########################################
+#
+#kubernetesEnrichment: 
+#  module: kuberntes-enrichment
+#  debug: false
+#
+##########################################
+
+##########################################
 # REMOVE FIELDS
 # Documentation: https://sematext.com/docs/logagent/output-filter-removefields/
 ##########################################

--- a/dockerhub/run.sh
+++ b/dockerhub/run.sh
@@ -62,8 +62,13 @@ if [[ -z "$LOG_GLOB" ]]; then
   echo "You need to specify a log source. Mount the docker socket or set the LOG_GLOB in the environment!" >&2
 fi
 
+if [[ -n "${KUBERNETES_SERVICE_HOST}" ]]; then
+    # K8S env -> use k8sEnrichment plugin
+    export LOGAGENT_ARGS="--k8sEnrichment ${LOGAGENT_ARGS}"  
+fi
 
 if [[ ! -r /var/run/docker.sock ]]; then
+  # no docker socket
   if [[ -n "${KUBERNETES_SERVICE_HOST}" ]]; then
     # no docker socket & K8S env -> use containerd plugin
     export LOGAGENT_ARGS="--k8sContainerd ${LOGAGENT_ARGS}"  

--- a/lib/core/cliArgs.js
+++ b/lib/core/cliArgs.js
@@ -134,6 +134,7 @@ module.exports = (function () {
     .option('--dockerEvents', 'collects Docker events from /var/run/docker.sock')
     .option('--k8sContainerd', 'loads kubernetes containerd input-filter plugin')
     .option('--k8sEvents', 'collects Kubernetes events from Kubernetes API')
+    .option('--k8sEnrichment', 'log enrichment via Kubernetes API')
     .option('--printStats <period>', 'prints activity stats every N seconds, useful in comb. with -s to see activity', parseInt)
     .option('--stdin', 'read logs from stdin (default) when no other input is specified')
     .option('-u, --udp <port>', 'starts UDP syslog listener to receive logs')

--- a/lib/parser/mergePatternFiles.js
+++ b/lib/parser/mergePatternFiles.js
@@ -70,8 +70,12 @@ function loadConfigFiles (files, notifyCallback) {
     logger.debug('merge pattern file ' + file)
     var cfg = {}
     try {
-      cfg = yaml.load(fs.readFileSync(file, 'utf8'))
-      cfg._fileName = file
+      if (fs.existsSync(file)) {
+        cfg = yaml.load(fs.readFileSync(file, 'utf8'))
+        cfg._fileName = file
+      } else { 
+        logger.info('merge patterns file: not found ' + file)
+      }
     } catch (e) {
       cfg.patterns = []
       logger.error('ignoring pattern file ' + file + ' ' + e)

--- a/lib/parser/parser.js
+++ b/lib/parser/parser.js
@@ -255,12 +255,15 @@ LogParser.prototype = {
     } else {
       this.sources[sourceName] = {}
       var include = this.patterns.filter(function includeSourceFilter (p) {
-        if (sourceName && sourceName.match && sourceName.match(p.sourceName)) {
-          return true
+        if (sourceName && sourceName.match) {
+          return sourceName.match(p.sourceName) != null
+        }
+        if (p && p.sourceName && p.sourceName.test) {
+          return p.sourceName.test(sourceName)
         }
       })
       if (include.length > 0) {
-        this.sources[sourceName].reader = new MultiLine(include[0].blockStart, parser)
+        this.sources[sourceName].reader = new MultiLine(include[0].blockStart, parser) 
         return this.sources[sourceName].reader
       } else {
         this.sources[sourceName].reader = new MultiLine(

--- a/lib/plugins/input/docker/docker.js
+++ b/lib/plugins/input/docker/docker.js
@@ -62,10 +62,8 @@ function InputDockerSocket (config, eventEmitter) {
   // close log stream if any output filter emits the 'dropLogsRequest' event
   var self = this
   eventEmitter.on('dropLogsRequest', function (context, data) {
-    // consoleLogger.error('dropLogsRequest')
     if (self.lh) {
       self.lh.detachContainer(context.container_id)
-      // console.error('Log collection disabled, detached log stream ' + context.container_id + ' ' + context.container_name)
     }
   })
 }
@@ -134,13 +132,6 @@ InputDockerSocket.prototype.connect = function () {
       if (ignoreLogsPattern && ignoreLogsPattern.test(chunk.line)) {
         return cb()
       }
-      /*
-      var lines = chunk.line.split(/\n/)
-      for (var i = 0; i < lines.length; i++) {
-        self.logLine(lines[i].trim(), chunk)
-        console.error('LINES', i, lines.length, lines[i], chunk.image)
-      }
-      */
       self.logLine(chunk.line, chunk)
       cb()
     })

--- a/lib/plugins/input/docker/docker.js
+++ b/lib/plugins/input/docker/docker.js
@@ -135,7 +135,7 @@ InputDockerSocket.prototype.connect = function () {
     self.logStream.on('error', this.reconnect.bind(this))
     this.lh.pipe(self.logStream).on('error', this.reconnect.bind(this))
   } catch (ex) {
-    consoleLogger('error', 'reconnect to docker socket in 10 sec ...')
+    consoleLogger.error('reconnect to docker socket in 10 sec ...')
     setTimeout(this.reconnect.bind(this), 10000)
   }
 }

--- a/lib/plugins/input/docker/docker.js
+++ b/lib/plugins/input/docker/docker.js
@@ -59,6 +59,15 @@ function InputDockerSocket (config, eventEmitter) {
       return (dockerInfo.LOGSENE_ENABLED === true)
     }
   }
+  // close log stream if any output filter emits the 'dropLogsRequest' event
+  var self = this
+  eventEmitter.on('dropLogsRequest', function (context, data) {
+    // consoleLogger.error('dropLogsRequest')
+    if (self.lh) {
+      self.lh.detachContainer(context.container_id)
+      // console.error('Log collection disabled, detached log stream ' + context.container_id + ' ' + context.container_name)
+    }
+  })
 }
 
 function getTaggingLabels (dockerInspect) {
@@ -125,6 +134,13 @@ InputDockerSocket.prototype.connect = function () {
       if (ignoreLogsPattern && ignoreLogsPattern.test(chunk.line)) {
         return cb()
       }
+      /*
+      var lines = chunk.line.split(/\n/)
+      for (var i = 0; i < lines.length; i++) {
+        self.logLine(lines[i].trim(), chunk)
+        console.error('LINES', i, lines.length, lines[i], chunk.image)
+      }
+      */
       self.logLine(chunk.line, chunk)
       cb()
     })

--- a/lib/plugins/input/kubernetesEvents.js
+++ b/lib/plugins/input/kubernetesEvents.js
@@ -1,45 +1,55 @@
 // Emit k8s events as Node.js events
+const { KubeConfig } = require('kubernetes-client')
 const Client = require('kubernetes-client').Client
-const config = require('kubernetes-client').config
-const JSONStream = require('json-stream')
-var consoleLogger = require('../../util/logger.js')
-var EventEmitter = require('events').EventEmitter
+const Request = require('kubernetes-client/backends/request')
+const consoleLogger = require('../../util/logger.js')
+const EventEmitter = require('events').EventEmitter
 
 class KubernetesEventEmitter extends EventEmitter {
   constructor () {
     super()
+    const kubeconfig = new KubeConfig()
     // do we run in k8s cluster?
     if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
-      this.client = new Client({ config: config.getInCluster() })
+      // this.client = new Client({ config: config.getInCluster() })
+      kubeconfig.loadFromCluster()   
     } else {
-      this.client = new Client({ config: config.fromKubeconfig() })
+      kubeconfig.loadFromDefault()
     }
+    this.client = new Client({ backend: new Request({ kubeconfig }) })
     this.client.loadSpec().then(this.start.bind(this)).catch(error => {
-      console.error(error)
+      console.error('Error in k8s client', error)
     })
   }
 
-  startWatching () {
+  async startWatching (namespace, cb) {
     var self = this
     // API docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#list-all-namespaces-event-v1-core
-    self.stream = self.client.api.v1.events.getStream()
-    self.jsonStream = new JSONStream()
-    self.stream.pipe(this.jsonStream)
-    self.jsonStream.on('data', object => {
-      for (var i = 0; i < object.items.length; i++) {
-        self.emit('event', object.items[i])
-      }
+    // https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#getstream
+    self[namespace] = await this.client.api.v1.watch.namespaces(namespace).pods.getObjectStream()
+    self[namespace].on('data', object => {
+      // console.log(object)
+      self.emit('event', object)
     })
-    self.stream.on('error', function (err) {
+    self[namespace].on('error', function (err) {
       self.emit('error', err)
       self.stop()
-      self.startWatching()
+      self.startWatching(namespace, cb)
     })
+    cb()
   }
 
-  start () {
+  async startWatchingAllNamespaces (callback) {
+    const namespaces = await this.client.api.v1.namespaces.get()
+    for (var i = 0; i < namespaces.length; i++) {
+      this.startWatching(namespaces[i], callback)
+    }
+    callback()
+  }
+
+  start (cb) {
     try {
-      this.startWatching()
+      this.startWatchingAllNamespaces(() => {})
     } catch (err) {
       this.emitter.emit('error', err)
       consoleLogger.error('KubernetesEvents error: ' + err)
@@ -76,7 +86,7 @@ KubernetesEvents.prototype.addTags = function (log) {
 }
 
 KubernetesEvents.prototype.start = function () {
-  var context = {name: 'k8s', sourceName: this.config.sourceName || 'k8s'}
+  var context = { name: 'k8s', sourceName: this.config.sourceName || 'k8s' }
   var self = this
   this.k8s = new KubernetesEventEmitter()
   this.k8s.on('event', function (event) {

--- a/lib/plugins/input/kubernetesEvents.js
+++ b/lib/plugins/input/kubernetesEvents.js
@@ -11,8 +11,7 @@ class KubernetesEventEmitter extends EventEmitter {
     const kubeconfig = new KubeConfig()
     // do we run in k8s cluster?
     if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
-      // this.client = new Client({ config: config.getInCluster() })
-      kubeconfig.loadFromCluster()   
+      kubeconfig.loadFromCluster() 
     } else {
       kubeconfig.loadFromDefault()
     }
@@ -28,7 +27,6 @@ class KubernetesEventEmitter extends EventEmitter {
     // https://github.com/godaddy/kubernetes-client/blob/master/merging-with-kubernetes.md#getstream
     self[namespace] = await this.client.api.v1.watch.namespaces(namespace).pods.getObjectStream()
     self[namespace].on('data', object => {
-      // console.log(object)
       self.emit('event', object)
     })
     self[namespace].on('error', function (err) {

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -1,20 +1,27 @@
 const { KubeConfig } = require('kubernetes-client')
 const Client = require('kubernetes-client').Client
 const Request = require('kubernetes-client/backends/request')
+
 const kubeconfig = new KubeConfig()
 var consoleLogger = require('../../util/logger.js')
-var podCache = {}
+var LRU = require('lru-cache')
+var podCache = new LRU({
+  max: 2000,
+  maxAge: 1000 * 60 * 60
+})
+
 var digestRegEx = /sha256:.+/i
 var client = null
 const FALSE_REGEX = /false/i
+
 if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
   kubeconfig.loadFromCluster()
 } else {
   kubeconfig.loadFromDefault()
 }
 client = new Client({ backend: new Request({ kubeconfig }) })
-client.loadSpec().then(() => {}).catch(error => {
-  console.error('Error in k8s client', error)
+client.loadSpec().catch(error => {
+  consoleLogger.error('Error in k8s client', error)
 })
 
 function kubernetesOutputFilter (context, config, eventEmitter, data, callback) {
@@ -32,25 +39,22 @@ function initKubernetesClient (config) {
   config.getPodSpec = function (namespace, podName, cb) {
     this.client.api.v1.namespaces(namespace).pods(podName).get(cb)
   }.bind(config)
-  // clean cache after 10 minutes
-  // TODO: use LRU Cache
-  setInterval(() => { podCache = {} }, 10 * 60 * 1000)
 }
 
 async function getPodSpec (config, namespace, podName, cb) {
   if (config.client && config.client.api) {
     var spec = await config.client.api.v1.namespaces(namespace).pods(podName).get()
-    cb(null, spec.body)
+    return spec// cb(null, spec.body)
   } else {
-    cb(new Error('Kuberntes API not ready'))
+    throw new Error ('Kuberntes API not ready')// cb(new Error('Kuberntes API not ready'))
   }
 }
 
-function removeFields (key, data) {
-  if (podCache[key].stRemoveFields === false) {
+function removeFields (pod, data) {
+  if (pod && pod.stRemoveFields === false) {
     return
   }
-  var annotations = podCache[key].metadata.annotations
+  var annotations = pod.metadata.annotations
   var removeFields = annotations['REMOVE_FIELDS'] || annotations['sematext.com/logs-remove-fields']
   if (removeFields) {
     var fieldNames = removeFields.split(',')
@@ -58,59 +62,48 @@ function removeFields (key, data) {
       delete data[fieldNames[i]]
     }
   } else {
-    podCache[key].stRemoveFields = false
+    pod.stRemoveFields = false
   }
 }
 
-function checkLogsEnabled (key, data, context) {
-  if (podCache[key].stLogEnabled === false) {
+function checkLogsEnabled (pod, data, context) {
+  if (pod.stLogEnabled === false) {
     data.stLogEnabled = false
     return
   }
-  var annotations = podCache[key].metadata.annotations
+  var annotations = pod.metadata.annotations
   if (annotations) {
     var logsEnabled = annotations['sematext.com/logs-enabled']
     if (FALSE_REGEX.test(logsEnabled)) {
       data.stLogEnabled = false
-      podCache[key].stLogEnabled = false
+      pod.stLogEnabled = false
       if (process.env.DEBUG) {
-        console.error('stLogEnabled = false', key)
+        consoleLogger.error('stLogEnabled = false', key)
       }
     } else {
-      podCache[key].stLogEnabled = true
+      pod.stLogEnabled = true
     }
   }
 }
 
-function addLogsIndex (key, data) {
-  if (podCache[key].stLogsTokenSet === false) {
+function addLogsIndex (pod, data) {
+  if (pod.stLogsTokenSet === false) {
     return
   }
   // get ST Logs Token from pod annotation
-  var index = podCache[key].metadata.annotations['sematext.com/logs-token']
+  var index = pod.metadata.annotations['sematext.com/logs-token']
   // get comma separated list of fields from pod annotation
   if (index) {
     data._index = index
   } else {
-    podCache[key].stLogsTokenSet = false
-  }
-}
-/*
-
-function updatePodUid (key, data) {
-  if (data.kubernetes && podCache[key]) {
-    data.kubernetes.pod.uid = podCache[key].metadata.uid
-  } else {
-    podCache[key].stLogsTokenSet = false
+    pod.stLogsTokenSet = false
   }
 }
 
-*/
-
-function replaceDockerImageName (key, data) {
-  if (data.kubernetes && data.container && podCache[key].stImageCache) {
+function replaceDockerImageName (pod, data) {
+  if (data.kubernetes && data.container && pod.stImageCache) {
     var containerName = data.kubernetes.pod.container.name
-    var imageInfo = podCache[key].stImageCache[data.kubernetes.pod.name + containerName]
+    var imageInfo = pod.stImageCache[data.kubernetes.pod.name + containerName]
     if (!imageInfo) {
       return
     }
@@ -119,93 +112,90 @@ function replaceDockerImageName (key, data) {
     }
     data.container.image.name = imageInfo.name
     data.container.image.tag = imageInfo.tag
-    // data.container.image.registry = imageInfo.version
-    // data.container.image.name = imageInfo.plainImageName
   } else {
-    podCache[key].stLogsTokenSet = false
+    pod.stLogsTokenSet = false
   }
 }
 
 function processAnnotations (data, context) {
-  var key = data.kubernetes.namespace + '/' + data.kubernetes.pod.name
-  if (podCache[key] && podCache[key].metadata) {
-    checkLogsEnabled(key, data, context)
+  var pod = podCache.get(data.kubernetes.namespace + '/' + data.kubernetes.pod.name)
+  if (pod && pod.metadata) {
+    checkLogsEnabled(pod, data, context)
     if (data.stLogEnabled === false) {
       // logs will be droped, so no need for other processing
       return
     }
-    // updatePodUid (key, data)
-    replaceDockerImageName(key, data)
-    removeFields(key, data)
-    addLogsIndex(key, data)
+    replaceDockerImageName(pod, data)
+    removeFields(pod, data)
+    addLogsIndex(pod, data)
   }
 }
 
 function enrichLogs (context, config, eventEmitter, data, callback) {
-  if (data.kubernetes && data.kubernetes.pod) {
-    if (podCache[data.kubernetes.namespace + '/' + data.kubernetes.pod.name]) {
-      processAnnotations(data, context)
-      if (data.stLogEnabled === false) {
-        // allow input plugins to close the input stream, e.g. input/docker/docker.js
-        eventEmitter.emit('dropLogsRequest', context, data)
-        if (config.debug == true) { 
-          console.log('logs dropped ', data.kubernetes.namespace + '/' + data.kubernetes.pod.name, data.message)
-        }
-        return callback()
-      } else {
-        return callback(null, data)
+  if (!(data.kubernetes && data.kubernetes.pod)) {
+    return callback(null, data)
+  }
+
+  if (podCache.get(data.kubernetes.namespace + '/' + data.kubernetes.pod.name)) {
+    processAnnotations(data, context)
+    if (data.stLogEnabled === false) {
+      // allow input plugins to close the input stream, e.g. input/docker/docker.js
+      eventEmitter.emit('dropLogsRequest', context, data)
+      if (config.debug === true) {
+        consoleLogger.log('logs dropped ' + data.kubernetes.namespace + '/' + data.kubernetes.pod.name, data.message)
       }
+      return callback()
     } else {
-      getPodSpec(
-        config,
-        data.kubernetes.namespace,
-        data.kubernetes.pod.name,
-        function (err, pod) {
-          if (err) {
-            consoleLogger.log(err.message)
-            return callback(null, data)
-          }
-          podCache[data.kubernetes.namespace + '/' + data.kubernetes.pod.name] = pod
-          // create hashtable with containerName -> imageInformation
-          pod.stImageCache = {}
-          if (pod.spec && pod.spec.containers) {
-            var podContainers = pod.spec.containers
-            for (var i = 0; i < podContainers.length; i++) {
-              var container = podContainers[i]
-              // split imageName:version
-              var imageInfo = container.image.split(':')
-              // split registry/imageName
-              var imageRegistryInfo = container.image.split('/')
-              var imageKey = pod.metadata.name + container.name
-              pod.stImageCache[imageKey] = {
-                image: container.image,
-                name: imageInfo[0],
-                registry: imageRegistryInfo[0]
-              }
-              if (imageInfo.length > 1) {
-                pod.stImageCache[imageKey].tag = imageInfo[1]
-              }
-              if (imageRegistryInfo.length > 1) {
-                pod.stImageCache[imageKey].plainImageName = imageRegistryInfo[1]
-              }
-            }
-          }
-          if (config.debug) {
-            console.log('pod spec:', JSON.stringify(pod, null, ' '))
-          }
-          processAnnotations(data, context)
-          if (data.stLogEnabled === false) {
-            // allow input plugins to close the input stream, e.g. input/docker/docker.js
-            eventEmitter.emit('dropLogsRequest', context, data)
-            return callback()
-          } else {
-            return callback(null, data)
-          }
-        }
-      )
+      return callback(null, data)
     }
   } else {
-    return callback(null, data)
+    getPodSpec(
+      config,
+      data.kubernetes.namespace,
+      data.kubernetes.pod.name,
+      function (err, pod) {
+        if (err) {
+          consoleLogger.log(err.message)
+          return callback(null, data)
+        }
+        podCache.set(data.kubernetes.namespace + '/' + data.kubernetes.pod.name, pod)
+        // create hashtable with containerName -> imageInformation
+        pod.stImageCache = {}
+        if (pod.spec && pod.spec.containers) {
+          var podContainers = pod.spec.containers
+          for (var i = 0; i < podContainers.length; i++) {
+            var container = podContainers[i]
+            // split imageName:version
+            var imageInfo = container.image.split(':')
+            // split registry/imageName
+            var imageRegistryInfo = container.image.split('/')
+            var imageKey = pod.metadata.name + container.name
+            pod.stImageCache[imageKey] = {
+              image: container.image,
+              name: imageInfo[0],
+              registry: imageRegistryInfo[0]
+            }
+            if (imageInfo.length > 1) {
+              pod.stImageCache[imageKey].tag = imageInfo[1]
+            }
+            if (imageRegistryInfo.length > 1) {
+              pod.stImageCache[imageKey].plainImageName = imageRegistryInfo[1]
+            }
+          }
+        }
+        if (config.debug) {
+          consoleLogger.log('pod spec: ' + JSON.stringify(pod, null, ' '))
+        }
+        processAnnotations(data, context)
+        if (data.stLogEnabled === false) {
+          // allow input plugins to close the input stream, e.g. input/docker/docker.js
+          eventEmitter.emit('dropLogsRequest', context, data)
+          return callback()
+        } else {
+          return callback(null, data)
+        }
+      }
+    )
   }
 }
 

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -2,9 +2,20 @@ const { KubeConfig } = require('kubernetes-client')
 const Client = require('kubernetes-client').Client
 const Request = require('kubernetes-client/backends/request')
 const kubeconfig = new KubeConfig()
-
+var consoleLogger = require('../../util/logger.js')
 var podCache = {}
 var digestRegEx = /sha256:.+/i
+var client = null
+const FASLE_REGEX = /false/i
+if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
+  kubeconfig.loadFromCluster()
+} else {
+  kubeconfig.loadFromDefault()
+}
+client = new Client({ backend: new Request({ kubeconfig }) })
+client.loadSpec().then(() => {}).catch(error => {
+  console.error('Error in k8s client', error)
+})
 
 function kubernetesOutputFilter (context, config, eventEmitter, data, callback) {
   // we use the config object to track state of each plugin instance
@@ -17,15 +28,7 @@ function kubernetesOutputFilter (context, config, eventEmitter, data, callback) 
 
 function initKubernetesClient (config) {
   // do we run in k8s cluster?
-  if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
-    kubeconfig.loadFromCluster()
-  } else {
-    kubeconfig.loadFromDefault()
-  }
-  config.client = new Client({ backend: new Request({ kubeconfig }) })
-  config.client.loadSpec().then(()=>{}).catch(error => {
-    console.error('Error in k8s client', error)
-  })
+  config.client = client
   config.getPodSpec = function (namespace, podName, cb) {
     this.client.api.v1.namespaces(namespace).pods(podName).get(cb)
   }.bind(config)
@@ -35,8 +38,12 @@ function initKubernetesClient (config) {
 }
 
 async function getPodSpec (config, namespace, podName, cb) {
-  var spec = await config.client.api.v1.namespaces(namespace).pods(podName).get()
-  cb(null, spec.body)
+  if (config.client && config.client.api) {
+    var spec = await config.client.api.v1.namespaces(namespace).pods(podName).get()
+    cb(null, spec.body)
+  } else {
+    cb(new Error('Kuberntes API not ready'))
+  }
 }
 
 function removeFields (key, data) {
@@ -55,16 +62,23 @@ function removeFields (key, data) {
   }
 }
 
-function dropLogs (key, data) {
-  if (podCache[key].stDropLogs === false) {
+function checkLogsEnabled (key, data, context) {
+  if (podCache[key].stLogEnabled === false) {
+    data.stLogEnabled = false
     return
   }
   var annotations = podCache[key].metadata.annotations
-  var dropLogs = annotations['LOGS_ENABLED'] || annotations['sematext.com/logs-enabled']
-  if (dropLogs === 'true') {
-    data.stDropLogs = true
-  } else {
-    podCache[key].stDropLogs = false
+  if (annotations) {
+    var logsEnabled = annotations['sematext.com/logs-enabled']
+    if (FALSE_REGEX.test(logsEnabled) {
+      data.stLogEnabled = false
+      podCache[key].stLogEnabled = false
+      if (process.env.DEBUG) {
+        console.error('stLogEnabled = false', key)
+      }
+    } else {
+      podCache[key].stLogEnabled = true
+    }
   }
 }
 
@@ -73,7 +87,7 @@ function addLogsIndex (key, data) {
     return
   }
   // get ST Logs Token from pod annotation
-  var index = podCache[key].metadata.annotations['LOGS_TOKEN'] || podCache[key].metadata.annotations['sematext.com/logs-token']
+  var index = podCache[key].metadata.annotations['sematext.com/logs-token']
   // get comma separated list of fields from pod annotation
   if (index) {
     data._index = index
@@ -112,11 +126,11 @@ function replaceDockerImageName (key, data) {
   }
 }
 
-function processAnnotations (data) {
-  var key = data.kubernetes.namespace + data.kubernetes.pod.name
+function processAnnotations (data, context) {
+  var key = data.kubernetes.namespace + '/' + data.kubernetes.pod.name
   if (podCache[key] && podCache[key].metadata) {
-    dropLogs(key, data)
-    if (data.dropLogs) {
+    checkLogsEnabled(key, data, context)
+    if (data.stLogEnabled === false) {
       // logs will be droped, so no need for other processing
       return
     }
@@ -129,10 +143,15 @@ function processAnnotations (data) {
 
 function enrichLogs (context, config, eventEmitter, data, callback) {
   if (data.kubernetes && data.kubernetes.pod) {
-    if (podCache[data.kubernetes.namespace + data.kubernetes.pod.name]) {
-      processAnnotations(data)
-      if (data.dropLogs) {
-        return callback(null, null)
+    if (podCache[data.kubernetes.namespace + '/' + data.kubernetes.pod.name]) {
+      processAnnotations(data, context)
+      if (data.stLogEnabled === false) {
+        // allow input plugins to close the input stream, e.g. input/docker/docker.js
+        eventEmitter.emit('dropLogsRequest', context, data)
+        if (config.debug == true) { 
+          console.log('logs dropped ', data.kubernetes.namespace + '/' + data.kubernetes.pod.name, data.message)
+        }
+        return callback()
       } else {
         return callback(null, data)
       }
@@ -143,9 +162,10 @@ function enrichLogs (context, config, eventEmitter, data, callback) {
         data.kubernetes.pod.name,
         function (err, pod) {
           if (err) {
+            consoleLogger.log(err.message)
             return callback(null, data)
           }
-          podCache[data.kubernetes.namespace + data.kubernetes.pod.name] = pod
+          podCache[data.kubernetes.namespace + '/' + data.kubernetes.pod.name] = pod
           // create hashtable with containerName -> imageInformation
           pod.stImageCache = {}
           if (pod.spec && pod.spec.containers) {
@@ -173,9 +193,11 @@ function enrichLogs (context, config, eventEmitter, data, callback) {
           if (config.debug) {
             console.log('pod spec:', JSON.stringify(pod, null, ' '))
           }
-          processAnnotations(data)
-          if (data.dropLogs) {
-            return callback(null, null)
+          processAnnotations(data, context)
+          if (data.stLogEnabled === false) {
+            // allow input plugins to close the input stream, e.g. input/docker/docker.js
+            eventEmitter.emit('dropLogsRequest', context, data)
+            return callback()
           } else {
             return callback(null, data)
           }

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -44,9 +44,9 @@ function initKubernetesClient (config) {
 async function getPodSpec (config, namespace, podName, cb) {
   if (config.client && config.client.api) {
     var spec = await config.client.api.v1.namespaces(namespace).pods(podName).get()
-    return spec// cb(null, spec.body)
+    cb(null, spec.body)
   } else {
-    throw new Error ('Kuberntes API not ready')// cb(new Error('Kuberntes API not ready'))
+    cb(new Error('Kuberntes API not ready'))
   }
 }
 

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -1,0 +1,87 @@
+const { KubeConfig } = require('kubernetes-client')
+const Client = require('kubernetes-client').Client
+const Request = require('kubernetes-client/backends/request')
+const kubeconfig = new KubeConfig()
+
+var podCache = {}
+
+function kubernetesOutputFilter (context, config, eventEmitter, data, callback) {
+  // we use the config object to track state of each plugin instance
+  if (!config.client) {
+    initKubernetesClient(config)
+  } else {
+    enrichLogs(context, config, eventEmitter, data, callback)
+  }
+}
+
+function initKubernetesClient (config) {
+  // do we run in k8s cluster?
+  if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
+    kubeconfig.loadFromCluster()
+  } else {
+    kubeconfig.loadFromDefault()
+  }
+  config.client = new Client({ backend: new Request({ kubeconfig }) })
+  config.client.loadSpec().then(this.start.bind(this)).catch(error => {
+    console.error('Error in k8s client', error)
+  })
+  config.getPodSpec = function (namespace, podName, cb) {
+    this.client.api.v1.namespaces(namespace).pods(podName).get(cb)
+  }.bind(config)
+  // clean cache after 10 minutes
+  // TODO: use LRU Cache
+  setInterval(() => { podCache = {} }, 10 * 60 * 1000)
+}
+
+async function getPodSpec (config, namespace, podName, cb) {
+  var spec = await config.client.api.v1.namespaces(namespace).pods(podName).get()
+  cb(null, spec.body)
+}
+
+function processAnnotations (data) {
+  if (podCache[data.kubernetes.namespace + data.kubernetes.pod.name]) {
+    // get ST Logs Token from pod annotation
+    var key = data.kubernetes.namespace + data.kubernetes.pod.name
+    var index = podCache[key]['LOGS_TOKEN']
+    // get comma separated list of fields from pod annotation
+    var removeFields = podCache[key]['REMOVE_FIELDS']
+    if (removeFields) {
+      var fieldNames = removeFields.split(',')
+      for (var i = 0; i < fieldNames.length; i++) {
+        delete data[fieldNames[i]]
+      }
+    }
+    if (index) {
+      data._index = index
+    }
+  }
+}
+
+function enrichLogs (context, config, eventEmitter, data, callback) {
+  if (data.kubernetes && data.kubernetes.pod) {
+    if (podCache[data.kubernetes.namespace + data.kubernetes.pod.name]) {
+      processAnnotations(data)
+      callback(null, data)
+    } else {
+      getPodSpec(
+        config,
+        data.kubernetes.namespace,
+        data.kubernetes.pod.name,
+        function (err, pod) {
+          if (err) {
+            return callback(null, data)
+          }
+          podCache[data.kubernetes.namespace + data.kubernetes.pod.name] = pod.metadata.annotations
+          // console.log('pod spec:', JSON.stringify(pod, null, ' '))
+          processAnnotations(data)
+          return callback(null, data)
+        }
+      )
+    }
+  } else {
+    return callback(null, data)
+  }
+  callback(null, data)
+}
+
+module.exports = kubernetesOutputFilter

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -4,6 +4,7 @@ const Request = require('kubernetes-client/backends/request')
 const kubeconfig = new KubeConfig()
 
 var podCache = {}
+var digestRegEx = /sha256:.+/i
 
 function kubernetesOutputFilter (context, config, eventEmitter, data, callback) {
   // we use the config object to track state of each plugin instance
@@ -22,7 +23,7 @@ function initKubernetesClient (config) {
     kubeconfig.loadFromDefault()
   }
   config.client = new Client({ backend: new Request({ kubeconfig }) })
-  config.client.loadSpec().then(this.start.bind(this)).catch(error => {
+  config.client.loadSpec().then(()=>{}).catch(error => {
     console.error('Error in k8s client', error)
   })
   config.getPodSpec = function (namespace, podName, cb) {
@@ -38,22 +39,91 @@ async function getPodSpec (config, namespace, podName, cb) {
   cb(null, spec.body)
 }
 
+function removeFields (key, data) {
+  if (podCache[key].stRemoveFields === false) {
+    return
+  }
+  var annotations = podCache[key].metadata.annotations
+  var removeFields = annotations['REMOVE_FIELDS'] || annotations['sematext.com/logs-remove-fields']
+  if (removeFields) {
+    var fieldNames = removeFields.split(',')
+    for (var i = 0; i < fieldNames.length; i++) {
+      delete data[fieldNames[i]]
+    }
+  } else {
+    podCache[key].stRemoveFields = false
+  }
+}
+
+function dropLogs (key, data) {
+  if (podCache[key].stDropLogs === false) {
+    return
+  }
+  var annotations = podCache[key].metadata.annotations
+  var dropLogs = annotations['LOGS_ENABLED'] || annotations['sematext.com/logs-enabled']
+  if (dropLogs === 'true') {
+    data.stDropLogs = true
+  } else {
+    podCache[key].stDropLogs = false
+  }
+}
+
+function addLogsIndex (key, data) {
+  if (podCache[key].stLogsTokenSet === false) {
+    return
+  }
+  // get ST Logs Token from pod annotation
+  var index = podCache[key].metadata.annotations['LOGS_TOKEN'] || podCache[key].metadata.annotations['sematext.com/logs-token']
+  // get comma separated list of fields from pod annotation
+  if (index) {
+    data._index = index
+  } else {
+    podCache[key].stLogsTokenSet = false
+  }
+}
+/*
+
+function updatePodUid (key, data) {
+  if (data.kubernetes && podCache[key]) {
+    data.kubernetes.pod.uid = podCache[key].metadata.uid
+  } else {
+    podCache[key].stLogsTokenSet = false
+  }
+}
+
+*/
+
+function replaceDockerImageName (key, data) {
+  if (data.kubernetes && data.container && podCache[key].stImageCache) {
+    var containerName = data.kubernetes.pod.container.name
+    var imageInfo = podCache[key].stImageCache[data.kubernetes.pod.name + containerName]
+    if (!imageInfo) {
+      return
+    }
+    if (data.container.image.name === 'sha256') {
+      data.container.image.digest = 'sha256:' + data.container.image.tag
+    }
+    data.container.image.name = imageInfo.name
+    data.container.image.tag = imageInfo.tag
+    // data.container.image.registry = imageInfo.version
+    // data.container.image.name = imageInfo.plainImageName
+  } else {
+    podCache[key].stLogsTokenSet = false
+  }
+}
+
 function processAnnotations (data) {
-  if (podCache[data.kubernetes.namespace + data.kubernetes.pod.name]) {
-    // get ST Logs Token from pod annotation
-    var key = data.kubernetes.namespace + data.kubernetes.pod.name
-    var index = podCache[key]['LOGS_TOKEN']
-    // get comma separated list of fields from pod annotation
-    var removeFields = podCache[key]['REMOVE_FIELDS']
-    if (removeFields) {
-      var fieldNames = removeFields.split(',')
-      for (var i = 0; i < fieldNames.length; i++) {
-        delete data[fieldNames[i]]
-      }
+  var key = data.kubernetes.namespace + data.kubernetes.pod.name
+  if (podCache[key] && podCache[key].metadata) {
+    dropLogs(key, data)
+    if (data.dropLogs) {
+      // logs will be droped, so no need for other processing
+      return
     }
-    if (index) {
-      data._index = index
-    }
+    // updatePodUid (key, data)
+    replaceDockerImageName(key, data)
+    removeFields(key, data)
+    addLogsIndex(key, data)
   }
 }
 
@@ -61,7 +131,11 @@ function enrichLogs (context, config, eventEmitter, data, callback) {
   if (data.kubernetes && data.kubernetes.pod) {
     if (podCache[data.kubernetes.namespace + data.kubernetes.pod.name]) {
       processAnnotations(data)
-      callback(null, data)
+      if (data.dropLogs) {
+        return callback(null, null)
+      } else {
+        return callback(null, data)
+      }
     } else {
       getPodSpec(
         config,
@@ -71,17 +145,46 @@ function enrichLogs (context, config, eventEmitter, data, callback) {
           if (err) {
             return callback(null, data)
           }
-          podCache[data.kubernetes.namespace + data.kubernetes.pod.name] = pod.metadata.annotations
-          // console.log('pod spec:', JSON.stringify(pod, null, ' '))
+          podCache[data.kubernetes.namespace + data.kubernetes.pod.name] = pod
+          // create hashtable with containerName -> imageInformation
+          pod.stImageCache = {}
+          if (pod.spec && pod.spec.containers) {
+            var podContainers = pod.spec.containers
+            for (var i = 0; i < podContainers.length; i++) {
+              var container = podContainers[i]
+              // split imageName:version
+              var imageInfo = container.image.split(':')
+              // split registry/imageName
+              var imageRegistryInfo = container.image.split('/')
+              var imageKey = pod.metadata.name + container.name
+              pod.stImageCache[imageKey] = {
+                image: container.image,
+                name: imageInfo[0],
+                registry: imageRegistryInfo[0]
+              }
+              if (imageInfo.length > 1) {
+                pod.stImageCache[imageKey].tag = imageInfo[1]
+              }
+              if (imageRegistryInfo.length > 1) {
+                pod.stImageCache[imageKey].plainImageName = imageRegistryInfo[1]
+              }
+            }
+          }
+          if (config.debug) {
+            console.log('pod spec:', JSON.stringify(pod, null, ' '))
+          }
           processAnnotations(data)
-          return callback(null, data)
+          if (data.dropLogs) {
+            return callback(null, null)
+          } else {
+            return callback(null, data)
+          }
         }
       )
     }
   } else {
     return callback(null, data)
   }
-  callback(null, data)
 }
 
 module.exports = kubernetesOutputFilter

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -6,7 +6,7 @@ var consoleLogger = require('../../util/logger.js')
 var podCache = {}
 var digestRegEx = /sha256:.+/i
 var client = null
-const FASLE_REGEX = /false/i
+const FALSE_REGEX = /false/i
 if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
   kubeconfig.loadFromCluster()
 } else {
@@ -70,7 +70,7 @@ function checkLogsEnabled (key, data, context) {
   var annotations = podCache[key].metadata.annotations
   if (annotations) {
     var logsEnabled = annotations['sematext.com/logs-enabled']
-    if (FALSE_REGEX.test(logsEnabled) {
+    if (FALSE_REGEX.test(logsEnabled)) {
       data.stLogEnabled = false
       podCache[key].stLogEnabled = false
       if (process.env.DEBUG) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "js-yaml": "^3.13.1",
     "json-influx": "^0.3.0",
     "json-stream": "^1.0.0",
-    "kubernetes-client": "^6.12.1",
+    "kubernetes-client": "^8.3.3",
     "logsene-js": "^1.1.64",
     "lru-cache": "^5.1.1",
     "maxmind": "^2.11.0",

--- a/patterns.yml
+++ b/patterns.yml
@@ -310,17 +310,32 @@ patterns:
   # name of the docker image
   # example: "1:M 22 Jul 21:58:28.146 # Server started, Redis version 3.0.2"
   sourceName: !!js/regexp /redis/i
+  blockStart: !!js/regexp /^\d+:.\s\d+/
   match:
   - type: redis
-    fields: [pid,node_type,ts,message]
-    regex: !!js/regexp /^(\d+):\w+\s(\d\d\s\w+.+)\s\W\s(.*)/
-  - type: redis
-    fields: [pid,ts,message]
-    regex: !!js/regexp /^\[(\d+)\]\s(.+?)\s\*\s(.+)/i
+    blockStart: !!js/regexp /^\d+:.\s\d+/
+    fields: [pid,role,ts,level,message]
+    regex: !!js/regexp /^(\d+):(\w+)\s+(\d\d\s\w+.+)\s+(\S)\s+([\S|\s]+)/
     dateFormat: DD MMM HH:mm:ss.SSS
-  - type: redis
-    regex: !!js/regexp /^(.*)/i
-    fields: message
+    transform: !!js/function >
+      function transformMessage (p) {
+        levels = {
+          '.': 'debug',
+          '-': 'verbose',
+          '*': 'notice',
+          '#': 'warning'
+        }
+        roles = {
+          'X': 'sentinel',
+          'C': 'RDB/AOF writing child',
+          'S': 'slave',
+          'M': 'master'
+        }
+        p.role = roles[p.role]
+        p.severity = levels[p.level] || p.level
+        // p.message = p.message.replace(/\r/g,'')
+        delete p.level 
+      } 
 
  - # Sonatype Nexus
   sourceName: !!js/regexp /nexus/


### PR DESCRIPTION
- New command-line argument `--k8sEnrichment` to enable the Kubernetes-Enrichment plugin
- Interpreting Kubernetes annotations 
  - `sematext.com/logs-token`, send pod logs to a specific Sematext Logs Token 
  - `sematext.com/logs-enabled`, enable/disable pod logs. 
  - `sematext.com/logs-remove-fields`, list of fields removed from pod logs 
- Update `container.image.name` with value from `pod.spec.container.image.name`
  Bugfix: Docker engine in k8s reports sha256:ID as image name, while the Kubernetes API
  provides the correct image name
- Other changes: 
  - Update kubernetes-events plugin to latest k8s API client
  - Update Redis logs pattern
  - Minor bug fixes: 
    - Catch `file not found error` when loading pattern files, 
    - Parser: Fix issue finding patterns for a source
