### PR TITLE
Add new pipeline event

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -156,6 +156,7 @@ function LaCli (options) {
     self.initState()
   })
 }
+
 LaCli.prototype.initFilter = function (type, filterFunctions) {
   consoleLogger.log('init filter: ' + type)
   this[type] = []
@@ -453,6 +454,7 @@ LaCli.prototype.initState = function () {
     }
     self.cli()
   })
+
   self.eventEmitter.once('input.stdin.end', function endOnStdinEof (line, context) {
     self.terminateRequest = true
     self.terminateReason = 'stdin closed'
@@ -466,7 +468,45 @@ LaCli.prototype.initState = function () {
   }, 1000)
   self.tid.unref()
 
-  self.eventEmitter.on('data.raw', function parseRaw (line, contextObj) {
+  // shared function to call output-filters and output plugins
+  // after parsing of DATA_RAW events and receiving DATA_OBJECT events
+  function applyOutputFilters (data, contextObj) {
+    if (data) {
+      var filteredData = data
+      var context = clone(contextObj)
+      co(function * () {
+        for (var i = 0; i < self.outputFilter.length; i++) {
+          filteredData = yield function (callback) {
+            self.outputFilter[i].func(context, self.outputFilter[i].config, eventEmitter, filteredData, callback)
+          }
+        }
+      }).then(function processOutput () {
+        if (!filteredData) {
+          return
+        }
+        if (context.enrichEvent) {
+          Object.keys(context.enrichEvent).forEach(function (key) {
+            data[key] = context.enrichEvent[key]
+          })
+        }
+        if (context.filter) {
+          filteredData = context.filter(data, context)
+        }
+        if (filteredData) {
+          self.eventEmitter.parsedEvent(filteredData, context)
+        }
+      }, function logError (e) {
+        // we avoid logging errors for each log line in prod mode
+        consoleLogger.debug(e.stack)
+      })
+    }
+  }
+
+  /**
+   * DATA_RAW events are emitted by input-plugins, producing text lines,
+   * and must be handled by text based input-filters and parser
+   **/
+  self.eventEmitter.on(eventEmitter.DATA_RAW, function parseRaw (line, contextObj) {
     self.lastParsedTS = Date.now()
     var context = contextObj
     var trimmedLine = line
@@ -488,52 +528,40 @@ LaCli.prototype.initState = function () {
           }
         }
       }
-    }).then(function () {
-      if (!trimmedLine) {
-        return
-      }
-      function parserCb (err, data) {
-        if (err && !data) {
-          consoleLogger.error('error during parsing: ' + err.stack)
+    }).then(
+      function processInput () {
+        if (!trimmedLine) {
+          return
         }
-        if (data) {
-          var filteredData = data
-          co(function * () {
-            for (var i = 0; i < self.outputFilter.length; i++) {
-              filteredData = yield function (callback) {
-                self.outputFilter[i].func(context, self.outputFilter[i].config, eventEmitter, filteredData, callback)
-              }
-            }
-          }).then(function () {
-            if (!filteredData) {
-              return
-            }
-            if (context.enrichEvent) {
-              Object.keys(context.enrichEvent).forEach(function (key) {
-                data[key] = context.enrichEvent[key]
-              })
-            }
-            if (context.filter) {
-              filteredData = context.filter(data, context)
-            }
-            if (filteredData) {
-              self.eventEmitter.parsedEvent(filteredData, context)
-            }
-          }, function (e) {
-            consoleLogger.debug(e.stack)
-          })
+        function parserCb (err, data) {
+          if (err && !data) {
+            consoleLogger.error('error during parsing: ' + err.stack)
+          }
+          applyOutputFilters(data, context)
         }
-      }
 
-      setImmediate(function laParse () {
-        self.la.parseLine(
-          trimmedLine.replace(self.removeAnsiColor, ''),
-          context.sourceName || self.argv.sourceName,
-          parserCb)
+        setImmediate(function laParse () {
+          self.la.parseLine(
+            trimmedLine.replace(self.removeAnsiColor, ''),
+            context.sourceName || self.argv.sourceName,
+            parserCb)
+        })
+      },
+      function logError (e) {
+        // we avoid logging errors for each log line in prod mode
+        consoleLogger.debug(e.stack)
       })
-    }, function (e) {
-      // consoleLogger.error(e.stack)
-    })
+  })
+
+  /**
+   * DATA_OBJECT events are emitted by input plugins, producing structured data,
+   * with no need to be parsed. Such data needs to be processed by output-filters and
+   * output plugins
+   * Skipping text based input filters and parser, and continue with directly output filters
+   * improves performance by saving serialisation to JSON and back to JS objects.
+   **/
+  self.eventEmitter.on(eventEmitter.DATA_OBJECT, function processObjectData (data, contextObj) {
+    applyOutputFilters(data, contextObj)
   })
 
   process.once('SIGINT', function () { self.terminate('SIGINT') })

--- a/lib/core/logEventEmitter.js
+++ b/lib/core/logEventEmitter.js
@@ -3,7 +3,12 @@ var EventEmitter = require('eventemitter3')
 var util = require('util')
 
 function LogEventEmitter () {
+  // text based input
   this.DATA_RAW = 'data.raw'
+  // object input, skips input-filters and parser
+  this.DATA_OBJECT = 'data.object'
+  // after parsing and processing by output-filters
+  // ready to store or ship data
   this.DATA_PARSED = 'data.parsed'
   EventEmitter.call(this)
 }

--- a/lib/plugins/input/cassandra.js
+++ b/lib/plugins/input/cassandra.js
@@ -29,7 +29,7 @@ InputCassandra.prototype.queryResultCb = function (err, result) {
         rows[i]['@timestamp'] = new Date()
       }
       rows[i].logSource = this.context.sourceName
-      this.eventEmitter.emit('data.parsed', rows[i], this.context)
+      this.eventEmitter.emit('data.object', rows[i], this.context)
     }
   } else {
     this.eventEmitter.emit('error', err)

--- a/lib/plugins/input/elasticsearchHttp.js
+++ b/lib/plugins/input/elasticsearchHttp.js
@@ -1,7 +1,6 @@
 var consoleLogger = require('../../util/logger.js')
 var http = require('http')
 var throng = require('throng')
-var safeStringify = require('fast-safe-stringify')
 const errResponse = '{"error":{"root_cause":[{"type":"action_request_validation_exception","reason":"Validation Failed: 1: no requests added;"}],"type":"action_request_validation_exception","reason":"Validation Failed: 1: no requests added;"},"status":400}'
 
 function InputElasticsearchHttp (config, eventEmitter) {
@@ -132,7 +131,7 @@ InputElasticsearchHttp.prototype.elasticSearchHttpHandler = function (req, res) 
         }
         msg._index = reqInfo.defaultIndex
         msg._type = reqInfo.defaultType
-        return self.eventEmitter.emit('data.raw', safeStringify(msg), {
+        return self.eventEmitter.emit('data.object', msg, {
           source: 'input-elasticsearch-http',
           index: msg._index
         })
@@ -152,7 +151,7 @@ InputElasticsearchHttp.prototype.elasticSearchHttpHandler = function (req, res) 
           if (lineObj.index) {
             var source = JSON.parse(document[offSet + 1])
             offSet += 2 // each index request has 2 lines, one command + one document
-            var emitMsg = safeStringify(createIndexCall(lineObj.index, source, reqInfo.defaultIndex, reqInfo.defaultType))
+            var emitMsg = createIndexCall(lineObj.index, source, reqInfo.defaultIndex, reqInfo.defaultType)
             var responseItem = {
               index: {
                 result: 'created',
@@ -163,7 +162,7 @@ InputElasticsearchHttp.prototype.elasticSearchHttpHandler = function (req, res) 
             responseItem._type = source._type
             responseItem._id = source._id
             okResponse.items.push(responseItem)
-            self.eventEmitter.emit('data.raw', emitMsg, { source: 'input-elasticsearch-http', index: lineObj.index._index })
+            self.eventEmitter.emit('data.object', emitMsg, { source: 'input-elasticsearch-http', index: lineObj.index._index })
           } else {
             consoleLogger.log('Command not supported yet: ' + document[offSet])
             offSet += 1

--- a/lib/plugins/input/elasticsearchQuery.js
+++ b/lib/plugins/input/elasticsearchQuery.js
@@ -1,5 +1,4 @@
 'use strict'
-var safeStringify = require('fast-safe-stringify')
 var elasticsearch = require('elasticsearch')
 var AWS = require('aws-sdk')
 
@@ -95,7 +94,7 @@ InputElasticsearchQuery.prototype.query = function () {
           data._id = result._id
           data._type = result._type
         }
-        self.eventEmitter.emit('data.raw', safeStringify(data), context)
+        self.eventEmitter.emit('data.object', data, context)
       })
     }
   }, function (error) {

--- a/lib/plugins/input/influxHttp.js
+++ b/lib/plugins/input/influxHttp.js
@@ -154,7 +154,7 @@ InputInfluxHttp.prototype.parse = function (body, url) {
         influxDbName: rv.influxDbName
       }
       if (rv.measurement) {
-        this.eventEmitter.emit('data.raw', JSON.stringify(rv), context)
+        this.eventEmitter.emit('data.object', rv, context)
       }
     } catch (err) {
       consoleLogger.error('Error parsing data from influx: ' + err + ' body: ' + body)

--- a/lib/plugins/input/journaldUpload.js
+++ b/lib/plugins/input/journaldUpload.js
@@ -1,6 +1,5 @@
 var consoleLogger = require('../../util/logger.js')
 var http = require('http')
-var safeStringify = require('fast-safe-stringify')
 var throng = require('throng')
 
 function JournaldUpload (config, eventEmitter) {
@@ -58,7 +57,7 @@ JournaldUpload.prototype.emitEvent = function (log, token) {
     log['_index'] = token
   }
   var context = { name: 'journald', sourceName: log['_SYSTEMD_UNIT'] || log['SYSLOG_IDENTIFIER'] || 'journald' }
-  this.eventEmitter.emit('data.raw', safeStringify(log), context)
+  this.eventEmitter.emit('data.object', log, context)
 }
 
 JournaldUpload.prototype.addTags = function (log) {

--- a/lib/plugins/input/kubernetesAudit.js
+++ b/lib/plugins/input/kubernetesAudit.js
@@ -1,6 +1,5 @@
 var consoleLogger = require('../../util/logger.js')
 var http = require('http')
-var safeStringify = require('fast-safe-stringify')
 var throng = require('throng')
 
 function KubernetesAudit (config, eventEmitter) {
@@ -35,7 +34,7 @@ KubernetesAudit.prototype.emitEvent = function (log, token) {
   if (token) {
     context.index = token
   }
-  this.eventEmitter.emit('data.raw', safeStringify(log), context)
+  this.eventEmitter.emit('data.object', log, context)
 }
 
 KubernetesAudit.prototype.addTags = function (log) {

--- a/lib/plugins/input/kubernetesEvents.js
+++ b/lib/plugins/input/kubernetesEvents.js
@@ -11,7 +11,7 @@ class KubernetesEventEmitter extends EventEmitter {
     const kubeconfig = new KubeConfig()
     // do we run in k8s cluster?
     if (process.env.KUBERNETES_PORT_443_TCP !== undefined) {
-      kubeconfig.loadFromCluster() 
+      kubeconfig.loadFromCluster()
     } else {
       kubeconfig.loadFromDefault()
     }
@@ -90,7 +90,7 @@ KubernetesEvents.prototype.start = function () {
   this.k8s.on('event', function (event) {
     self.addTags(event)
     event['@timestamp'] = event.firstTimestamp
-    self.eventEmitter.emit('data.parsed', event, context)
+    self.eventEmitter.emit('data.object', event, context)
   })
   this.k8s.on('error', function (error) {
     consoleLogger.error('Error in k8s event collector:' + error.message + ' ' + error.stack)

--- a/lib/plugins/input/mssql.js
+++ b/lib/plugins/input/mssql.js
@@ -29,7 +29,7 @@ InputMSSql.prototype.queryResultCb = function (err, rows) {
         var colName = currentRow[col].metadata.colName
         record[colName] = currentRow[col].value
       }
-      this.eventEmitter.emit('data.parsed', record, this.context)
+      this.eventEmitter.emit('data.object', record, this.context)
     }
   } else {
     this.eventEmitter.emit('error', err)

--- a/lib/plugins/input/mysql.js
+++ b/lib/plugins/input/mysql.js
@@ -21,7 +21,7 @@ InputMySql.prototype.queryResultCb = function (err, rows) {
         rows[i]['@timestamp'] = new Date()
       }
       rows[i].logSource = this.context.sourceName
-      this.eventEmitter.emit('data.parsed', rows[i], this.context)
+      this.eventEmitter.emit('data.object', rows[i], this.context)
     }
   } else {
     this.eventEmitter.emit('error', err)


### PR DESCRIPTION
A new event type `data.object` allows input plugins to emit structured data instead of text lines via `data.raw` events.
- parser and text-based input filters are skipped 
- output-filters are applied before output plugins get ‘data.parsed’ event
- input plugins adjustments using the new event type ‘data.object’. Some input plugins used stringify() and `data.raw` event. We changed the plugins to skip data serialization/deserialization and use directly `data.object` events with a better performance. Input plugins using 'data.parsed' have been changed to use the 'data.object' event, ensuring output filters can be applied.
