### PR TITLE
SC-7051: Added GitHub Webhook input plugin

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -58,6 +58,7 @@ var moduleAlias = {
   'apple-location': 'logagent-apple-location',
   'cassandra-query': '../lib/plugins/input/cassandra.js',
   'docker-logs': '../lib/plugins/input/docker/docker.js',
+  'input-github-webhook': '../lib/plugins/input/github.js',
   // input filters
   'input-filter-k8s-containerd': '../lib/plugins/input-filter/kubernetesContainerd.js',
   'grep': '../lib/plugins/input-filter/grep.js',

--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -86,7 +86,8 @@ var moduleAlias = {
   'output-zeromq': 'logagent-output-zeromq',
   'output-influxdb': '../lib/plugins/output/influxdb.js',
   'output-clickhouse': '../lib/plugins/output/clickhouse.js',
-  'output-http': '../lib/plugins/output/output-http.js'
+  'output-http': '../lib/plugins/output/output-http.js',
+  'output-sematext-events': '../lib/plugins/output/output-sematext-events.js'
 }
 
 function getFunctionArgumentNames (func) {

--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -58,7 +58,7 @@ var moduleAlias = {
   'apple-location': 'logagent-apple-location',
   'cassandra-query': '../lib/plugins/input/cassandra.js',
   'docker-logs': '../lib/plugins/input/docker/docker.js',
-  'input-github-webhook': '../lib/plugins/input/github.js',
+  'input-github-webhook': '../lib/plugins/input/webhooks/github.js',
   // input filters
   'input-filter-k8s-containerd': '../lib/plugins/input-filter/kubernetesContainerd.js',
   'grep': '../lib/plugins/input-filter/grep.js',

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -1,16 +1,13 @@
 input:
   github-webhook:
     module: input-github-webhook
-    port: 7700
+    port: 9200
     tags:
-      github: notification
+      - github
+      - notification
       
 output: 
-  http-forwarding:
-    module: output-http
-    url: https://event-receiver.apps.test.sematext.com/c2425ff2-5e84-4bf2-b81c-a89564438af7/event
-    # flush interval in seconds
-    flushInterval: 1
-    # max buffer size to force flush
-    maxBufferSize: 1
-    # debug: true
+  stdout: yaml
+  # http-forwarding:
+  #   module: output-http
+  #   url: https://event-receiver.apps.test.sematext.com/c2425ff2-5e84-4bf2-b81c-a89564438af7/event

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -1,11 +1,9 @@
-# Global options
-options:
-  includeOriginalLine: true
-
 input:
   github-webhook:
     module: input-github-webhook
     port: 7700
+    tags:
+      github: notification
       
 output: 
   http-forwarding:
@@ -15,4 +13,4 @@ output:
     flushInterval: 1
     # max buffer size to force flush
     maxBufferSize: 1
-    debug: true
+    # debug: true

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -2,7 +2,7 @@ input:
   github-webhook:
     module: input-github-webhook
     port: 9200
-    # useIndexFromUrlPath: true
+    useIndexFromUrlPath: true
     tags:
       - github
       - webhook

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -2,6 +2,7 @@ input:
   github-webhook:
     module: input-github-webhook
     port: 9200
+    useIndexFromUrlPath: true
     tags:
       - github
       - notification
@@ -11,3 +12,12 @@ output:
   # http-forwarding:
   #   module: output-http
   #   url: https://event-receiver.apps.test.sematext.com/c2425ff2-5e84-4bf2-b81c-a89564438af7/event
+  
+  
+  # add sematext-events-output
+  # only use region US or EU and get token from input URL
+  # if STE or test env expose `url`
+  # have all these values in the webhook input URL and parse them from there
+
+  # the URL should be similar to:
+  # webhook.sematext.com/github/<TOKEN>/<REGION>

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -13,6 +13,7 @@ output:
   http-forwarding:
     module: output-http
     url: https://event-receiver.apps.test.sematext.com/d111023d-f37c-4ae8-9999-8749d3ad391b/event
+    debug: true
   
   
   # add sematext-events-output

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -1,0 +1,18 @@
+# Global options
+options:
+  includeOriginalLine: true
+
+input:
+  github-webhook:
+    module: input-github-webhook
+    port: 7700
+      
+output: 
+  http-forwarding:
+    module: output-http
+    url: https://event-receiver.apps.test.sematext.com/c2425ff2-5e84-4bf2-b81c-a89564438af7/event
+    # flush interval in seconds
+    flushInterval: 1
+    # max buffer size to force flush
+    maxBufferSize: 1
+    debug: true

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -5,13 +5,14 @@ input:
     useIndexFromUrlPath: true
     tags:
       - github
+      - webhook
       - notification
       
 output: 
-  stdout: yaml
-  # http-forwarding:
-  #   module: output-http
-  #   url: https://event-receiver.apps.test.sematext.com/c2425ff2-5e84-4bf2-b81c-a89564438af7/event
+  # stdout: yaml
+  http-forwarding:
+    module: output-http
+    url: https://event-receiver.apps.test.sematext.com/d111023d-f37c-4ae8-9999-8749d3ad391b/event
   
   
   # add sematext-events-output

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -2,7 +2,7 @@ input:
   github-webhook:
     module: input-github-webhook
     port: 9200
-    useIndexFromUrlPath: true
+    # useIndexFromUrlPath: true
     tags:
       - github
       - webhook

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -10,16 +10,16 @@ input:
       
 output: 
   # stdout: yaml
-  http-forwarding:
-    module: output-http
-    url: https://event-receiver.apps.test.sematext.com/d111023d-f37c-4ae8-9999-8749d3ad391b/event
-    debug: true
-  
-  # st-events:
-  #   module: output-sematext-events
-  #   region: us # eu
-  #   receiver: https://event-receiver.apps.test.sematext.com
+  # http-forwarding:
+  #   module: output-http
+  #   url: https://event-receiver.apps.test.sematext.com/d111023d-f37c-4ae8-9999-8749d3ad391b/event
   #   debug: true
+  
+  st-events:
+    module: output-sematext-events
+    receiver: https://event-receiver.apps.test.sematext.com
+    debug: true
+    # region: us # eu
   
   # add sematext-events-output
   # only use region US or EU and get token from input URL

--- a/config/examples/github-webhook-input.yaml
+++ b/config/examples/github-webhook-input.yaml
@@ -15,6 +15,11 @@ output:
     url: https://event-receiver.apps.test.sematext.com/d111023d-f37c-4ae8-9999-8749d3ad391b/event
     debug: true
   
+  # st-events:
+  #   module: output-sematext-events
+  #   region: us # eu
+  #   receiver: https://event-receiver.apps.test.sematext.com
+  #   debug: true
   
   # add sematext-events-output
   # only use region US or EU and get token from input URL

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -1,0 +1,149 @@
+var consoleLogger = require('../../util/logger.js')
+var http = require('http')
+var safeStringify = require('fast-safe-stringify')
+var throng = require('throng')
+
+function GitHub (config, eventEmitter) {
+  this.config = config
+  this.eventEmitter = eventEmitter
+  if (config.worker) {
+    this.config.worker = config.workers
+  } else {
+    this.config.workers = 0
+  }
+}
+
+GitHub.prototype.start = function () {
+  if (this.config.workers && this.config.workers > 0) {
+    throng({
+      workers: this.config.workers,
+      lifetime: Infinity
+    }, this.startGitHub.bind(this))
+  } else {
+    this.startGitHub(1)
+  }
+}
+
+GitHub.prototype.stop = function (cb) {
+  cb()
+}
+
+GitHub.prototype.emitEvent = function (log, token) {
+  var config = this.config
+  var context = { name: 'GitHub', sourceName: 'GitHub' }
+  if (token) {
+    context.index = token
+  }
+  this.eventEmitter.emit('data.raw', safeStringify(log), context)
+}
+
+GitHub.prototype.addTags = function (log) {
+  if (this.config.tags === undefined) {
+    return
+  }
+  var keys = Object.keys(this.config.tags)
+  for (var i = 0; i < keys.length; i++) {
+    // avoid setting _index when passed in URL
+    if (log[keys[i]] === undefined) {
+      log[keys[i]] = this.config.tags[keys[i]]
+    }
+  }
+}
+
+GitHub.prototype.getHttpServer = function (aport, handler) {
+  var _port = aport || process.env.PORT || 9200
+  if (aport === true) {
+    _port = process.env.PORT
+  }
+  var server = http.createServer(handler)
+  try {
+    var bindAddress = this.config.bindAddress || '0.0.0.0'
+    server = server.listen(_port, bindAddress)
+    consoleLogger.log('Logagent listening (http k8s audit): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
+    return server
+  } catch (err) {
+    consoleLogger.log('Port in use k8s audit (' + _port + '): ' + err)
+  }
+}
+
+GitHub.prototype.parseHeaders = function (headers, token) {
+  var self = this
+  var docs = JSON.parse(body)
+  if (docs.items && docs.items.length > 0) {
+    for (var i = 0; i < docs.items.length; i++) {
+      var log = docs.items[i]
+      log['@timestamp'] = new Date(log.timestamp)
+      self.emitEvent(log, token)
+    }
+  }
+}
+
+GitHub.prototype.parseBody = function (body, token) {
+  var self = this
+  var docs = JSON.parse(body)
+  if (docs.items && docs.items.length > 0) {
+    for (var i = 0; i < docs.items.length; i++) {
+      var log = docs.items[i]
+      log['@timestamp'] = new Date(log.timestamp)
+      self.emitEvent(log, token)
+    }
+  }
+}
+
+GitHub.prototype.HttpHandler = function (req, res) {
+  try {
+    var self = this
+    var bodyIn = ''
+    var path = req.url.split('/')
+    var token = null
+    if (self.config.useIndexFromUrlPath === true && path.length > 1) {
+      if (path[1] && path[1].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[1])) {
+        token = path[1]
+      } else if (path[1] === 'health' || path[1] === 'ping') {
+        res.statusCode = 200
+        res.end('ok\n')
+        return
+      }
+    }
+    req.on('data', function (data) {
+      bodyIn += String(data)
+      // onsole.log(data)
+    })
+
+    req.on('end', function endHandler () {
+      self.parseBody(bodyIn, token) 
+      // send response to client
+      res.writeHead(
+        200,
+        { 'Content-Type': 'text/plain' }
+      )
+      res.end('OK\n')
+    })
+  } catch (err) {
+    res.statusCode = 500
+    res.end()
+    consoleLogger.error('Error in Kubernetes Audit HttpHandler: ' + err)
+  }
+}
+
+GitHub.prototype.startGitHub = function (id) {
+  this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
+  var exitInProgress = false
+  var terminate = function (reason) {
+    return function () {
+      if (exitInProgress) {
+        return
+      }
+      exitInProgress = true
+      consoleLogger.log('Stop k8s audit http worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
+      setTimeout(process.exit, 250)
+    }
+  }
+  process.once('SIGTERM', terminate('SIGTERM'))
+  process.once('SIGINT', terminate('SIGINT'))
+  process.once('exit', terminate('exit'))
+}
+
+module.exports = GitHub
+
+

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -2,115 +2,173 @@ var consoleLogger = require('../../util/logger.js')
 var http = require('http')
 var throng = require('throng')
 
-function GitHub (config, eventEmitter) {
-  this.config = config
-  this.eventEmitter = eventEmitter
-  if (config.worker) {
-    this.config.worker = config.workers
-  } else {
-    this.config.workers = 0
-  }
-}
-
-GitHub.prototype.start = function () {
-  if (this.config.workers && this.config.workers > 0) {
-    throng({
-      workers: this.config.workers,
-      lifetime: Infinity
-    }, this.startGitHubWebhookServer.bind(this))
-  } else {
-    this.startGitHubWebhookServer(1)
-  }
-}
-
-GitHub.prototype.stop = function (cb) {
-  cb()
-}
-
-GitHub.prototype.startGitHubWebhookServer = function (id) {
-  this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
-  var exitInProgress = false
-  var terminate = function (reason) {
-    return function () {
-      if (exitInProgress) {
-        return
-      }
-      exitInProgress = true
-      consoleLogger.log('Stop GitHub HTTP worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
-      setTimeout(process.exit, 250)
+class GitHub {
+  constructor (config, eventEmitter) {
+    this.config = config
+    this.eventEmitter = eventEmitter
+    if (config.worker) {
+      this.config.worker = config.workers
+    } else {
+      this.config.workers = 0
     }
   }
-  process.once('SIGTERM', terminate('SIGTERM'))
-  process.once('SIGINT', terminate('SIGINT'))
-  process.once('exit', terminate('exit'))
-}
 
-GitHub.prototype.getHttpServer = function (aport, handler) {
-  var _port = aport || process.env.PORT || 9200
-  if (aport === true) {
-    _port = process.env.PORT
+  start () {
+    if (this.config.workers && this.config.workers > 0) {
+      throng({
+        workers: this.config.workers,
+        lifetime: Infinity
+      }, this.startGitHubWebhookServer.bind(this))
+    } else {
+      this.startGitHubWebhookServer(1)
+    }
   }
-  var server = http.createServer(handler)
-  try {
-    var bindAddress = this.config.bindAddress || '0.0.0.0'
-    server = server.listen(_port, bindAddress)
-    consoleLogger.log('Logagent listening (HTTP GitHub): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
-    return server
-  } catch (err) {
-    consoleLogger.log('Port in use HTTP GitHub (' + _port + '): ' + err)
+
+  stop (cb) {
+    cb()
   }
-}
 
-GitHub.prototype.HttpHandler = function (req, res) {
-  try {
-    var self = this
-    var bodyIn = ''
-    var path = req.url.split('/')
-    var token = null
-    var region = null
-
-    // check if the useIndexFromUrlPath param is added in the YAML config
-    if (self.config.useIndexFromUrlPath === true && path.length > 1) {
-      if (path[1] === 'health' || path[1] === 'ping') {
-        res.statusCode = 200
-        res.end('ok\n')
-        return
-      }
-
-      if (path[1] !== 'github') {
-        res.statusCode = 400
-        res.end('Not a GitHub Webhook.\n')
-        return
-      }
-
-      if (path[2] && path[2].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])) {
-        token = path[2]
-      }
-
-      if (path[3] && (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')) {
-        region = path[3]
+  startGitHubWebhookServer (id) {
+    this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
+    var exitInProgress = false
+    var terminate = function (reason) {
+      return function () {
+        if (exitInProgress) {
+          return
+        }
+        exitInProgress = true
+        consoleLogger.log('Stop GitHub HTTP worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
+        setTimeout(process.exit, 250)
       }
     }
+    process.once('SIGTERM', terminate('SIGTERM'))
+    process.once('SIGINT', terminate('SIGINT'))
+    process.once('exit', terminate('exit'))
+  }
 
-    req.on('data', function (data) {
-      bodyIn += String(data)
-    })
+  getHttpServer (aport, handler) {
+    var _port = aport || process.env.PORT || 9200
+    if (aport === true) {
+      _port = process.env.PORT
+    }
+    var server = http.createServer(handler)
+    try {
+      var bindAddress = this.config.bindAddress || '0.0.0.0'
+      server = server.listen(_port, bindAddress)
+      consoleLogger.log('Logagent listening (HTTP GitHub): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
+      return server
+    } catch (err) {
+      consoleLogger.log('Port in use HTTP GitHub (' + _port + '): ' + err)
+    }
+  }
 
-    req.on('end', function endHandler () {
-      const log = self.parseReq({ headers: req.headers, body: bodyIn })
-      if (log) {
-        self.emitEvent(log, token, region)
+  HttpHandler (req, res) {
+    try {
+      var self = this
+      var bodyIn = ''
+      var path = req.url.split('/')
+      var token = null
+      var region = null
+      // check if the useIndexFromUrlPath param is added in the YAML config
+      if (self.config.useIndexFromUrlPath === true && path.length > 1) {
+        if (path[1] === 'health' || path[1] === 'ping') {
+          res.statusCode = 200
+          res.end('ok\n')
+          return
+        }
+        if (path[1] !== 'github') {
+          res.statusCode = 400
+          res.end('Not a GitHub Webhook.\n')
+          return
+        }
+        if (path[2] && path[2].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])) {
+          token = path[2]
+        }
+        if (path[3] && (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')) {
+          region = path[3]
+        }
       }
-      res.writeHead(
-        200,
-        { 'Content-Type': 'text/plain' }
-      )
-      res.end('OK\n')
-    })
-  } catch (err) {
-    res.statusCode = 500
-    res.end()
-    consoleLogger.error('Error in GitHub HttpHandler: ' + err)
+      req.on('data', function (data) {
+        bodyIn += String(data)
+      })
+      req.on('end', () => {
+        const log = self.parseReq({ headers: req.headers, body: bodyIn })
+        if (log) {
+          self.emitEvent(log, token, region)
+        }
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('OK\n')
+      })
+    } catch (err) {
+      res.statusCode = 500
+      res.end()
+      consoleLogger.error('Error in GitHub HttpHandler: ' + err)
+    }
+  }
+
+  parseReq (req) {
+    const body = JSON.parse(req.body)
+    /**
+     * x-github-event" headers that define what data to collect:
+     *
+     * issues
+     * issue_comment
+     * pull_request
+     * pull_request_review
+     * pull_request_review_comment
+     * commit_comment
+     * push
+     * create
+     * delete
+     * release
+     *
+     * add switch based on @event String to generate log fields
+     */
+    /**
+     * URL fields
+     * pull_request.html_url
+     * issue.html_url
+     * repository.html_url
+     * comment.html_url (comment.commit_id, comment.body)
+     */
+    /**
+     * Number fields
+     * pull_request.number
+     * issue.number
+     * repository.url
+     */
+    const event = req.headers['x-github-event']
+    // only send issue and pull request events down the pipeline
+    if (event === 'issues' ||
+      event === 'issue_comment' ||
+      event === 'pull_request' ||
+      event === 'pull_request_review' ||
+      event === 'pull_request_review_comment') {
+      return parseIssueOrPullRequest(event, body)
+    } else if (event === 'commit_comment') {
+      return parseCommitComment(event, body)
+    } else {
+      return null
+    }
+  }
+
+  emitEvent (log, token, region) {
+    var context = { name: 'GitHub', sourceName: 'GitHub' }
+    this.addTags(log)
+    if (token) {
+      context.index = token
+    }
+    if (region) {
+      context.region = region
+    }
+    this.eventEmitter.emit('data.object', log, context)
+  }
+
+  addTags (log) {
+    if (this.config.tags === undefined) {
+      return
+    }
+    log.tags = this.config.tags
   }
 }
 
@@ -166,74 +224,6 @@ const parseCommitComment = (event, body) => {
     ...initEvent(event, action),
     message: `#### [[${repoName}](${repoUrl})] - [${event} (${commitId})](${commitUrl}) "${commitMessage}" ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
   }
-}
-
-GitHub.prototype.parseReq = function (req) {
-  const body = JSON.parse(req.body)
-  /**
-   * x-github-event" headers that define what data to collect:
-   *
-   * issues
-   * issue_comment
-   * pull_request
-   * pull_request_review
-   * pull_request_review_comment
-   * commit_comment
-   * push
-   * create
-   * delete
-   * release
-   *
-   * add switch based on @event String to generate log fields
-   */
-
-  /**
-   * URL fields
-   * pull_request.html_url
-   * issue.html_url
-   * repository.html_url
-   * comment.html_url (comment.commit_id, comment.body)
-   */
-
-  /**
-   * Number fields
-   * pull_request.number
-   * issue.number
-   * repository.url
-   */
-
-  const event = req.headers['x-github-event']
-  // only send issue and pull request events down the pipeline
-  if (
-    event === 'issues' ||
-    event === 'issue_comment' ||
-    event === 'pull_request' ||
-    event === 'pull_request_review' ||
-    event === 'pull_request_review_comment'
-  ) {
-    return parseIssueOrPullRequest(event, body)
-  } else if (
-    event === 'commit_comment'
-  ) {
-    return parseCommitComment(event, body)
-  } else {
-    return null
-  }
-}
-
-GitHub.prototype.emitEvent = function (log, token, region) {
-  var context = { name: 'GitHub', sourceName: 'GitHub' }
-  this.addTags(log)
-  if (token) { context.index = token }
-  if (region) { context.region = region }
-  this.eventEmitter.emit('data.object', log, context)
-}
-
-GitHub.prototype.addTags = function (log) {
-  if (this.config.tags === undefined) {
-    return
-  }
-  log.tags = this.config.tags
 }
 
 module.exports = GitHub

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -29,8 +29,8 @@ GitHub.prototype.stop = function (cb) {
 }
 
 GitHub.prototype.emitEvent = function (log, token) {
-  // var config = this.config
-  var context = { name: 'GitHub', sourceName: 'GitHub' }
+  this.addTags(log)
+  var context = { name: 'GitHub', sourceName: 'GitHub', type: 'GitHub Event' }
   if (token) {
     context.index = token
   }
@@ -53,12 +53,48 @@ GitHub.prototype.getHttpServer = function (aport, handler) {
   }
 }
 
+GitHub.prototype.addTags = function (log) {
+  if (this.config.tags === undefined) {
+    return
+  }
+  var keys = Object.keys(this.config.tags)
+  for (var i = 0; i < keys.length; i++) {
+    if (log[keys[i]] === undefined) {
+      log[keys[i]] = this.config.tags[keys[i]]
+    }
+  }
+}
+
 GitHub.prototype.parseReq = function (req, token) {
   const self = this
-  const headers = JSON.parse(req.headers)
+  const headers = req.headers
+  const event = headers['x-github-event']
+  /**
+   * x-github-event" headers that define what data to collect:
+   *
+   * issues
+   * issue_comment
+   * pull_request
+   * pull_request_review
+   * pull_request_review_comment
+   * push
+   * create
+   * delete
+   * release
+   *
+   * add switch based on @event String to generate log fields
+   */
+
   const body = JSON.parse(req.body)
-  const log = { ...headers, ...body, '@timestamp': new Date() }
-  consoleLogger.log('log: ', log)
+  const { action } = body
+
+  const log = {
+    ...headers,
+    ...body,
+    severity: 'info',
+    title: `GitHub ${event} ${action}`,
+    message: `New event triggered on your repository. It was a ${event} ${action}.`
+  }
 
   /**
    * Needed format
@@ -84,6 +120,19 @@ GitHub.prototype.parseReq = function (req, token) {
     "creator" : "John Smith",
     "type" : "deployment"
   }'
+
+  OR
+
+  {
+    "timestamp": "2019-05-30T09:58:43.455Z",
+    "creator": "Jenkins",
+    "host": "jenkins-host",
+    "title": "Starting deployment",
+    "message": "Started deployment of Test v1.23 to production",
+    "severity": "info",
+    "type": "deployment",
+    "tags": ["version:1.23", "env:prod"],
+  }
  */
 
   self.emitEvent(log, token)
@@ -102,14 +151,13 @@ GitHub.prototype.HttpHandler = function (req, res) {
     })
 
     req.on('end', function endHandler () {
-      const log = self.parseReq({ headers: req.headers, body: bodyIn }, token)
+      self.parseReq({ headers: req.headers, body: bodyIn }, token)
       // send response to client
       res.writeHead(
         200,
         { 'Content-Type': 'text/plain' }
       )
-      // res.end('OK\n')
-      res.end(safeStringify(log))
+      res.end('OK\n')
     })
   } catch (err) {
     res.statusCode = 500

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -1,6 +1,6 @@
-var consoleLogger = require('../../util/logger.js')
-var http = require('http')
-var throng = require('throng')
+const consoleLogger = require('../../util/logger.js')
+const http = require('http')
+const throng = require('throng')
 
 class GitHub {
   constructor (config, eventEmitter) {
@@ -30,8 +30,8 @@ class GitHub {
 
   startGitHubWebhookServer (id) {
     this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
-    var exitInProgress = false
-    var terminate = function (reason) {
+    let exitInProgress = false
+    const terminate = function (reason) {
       return function () {
         if (exitInProgress) {
           return
@@ -47,16 +47,16 @@ class GitHub {
   }
 
   getHttpServer (aport, handler) {
-    var _port = aport || process.env.PORT || 9200
+    let _port = aport || process.env.PORT || 9200
     if (aport === true) {
       _port = process.env.PORT
     }
-    var server = http.createServer(handler)
+    const server = http.createServer(handler)
     try {
-      var bindAddress = this.config.bindAddress || '0.0.0.0'
-      server = server.listen(_port, bindAddress)
+      const bindAddress = this.config.bindAddress || '0.0.0.0'
+      const serverListening = server.listen(_port, bindAddress)
       consoleLogger.log('Logagent listening (HTTP GitHub): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
-      return server
+      return serverListening
     } catch (err) {
       consoleLogger.log('Port in use HTTP GitHub (' + _port + '): ' + err)
     }
@@ -64,38 +64,25 @@ class GitHub {
 
   HttpHandler (req, res) {
     try {
-      var self = this
-      var bodyIn = ''
-      var path = req.url.split('/')
-      var token = null
-      var region = null
-      // check if the useIndexFromUrlPath param is added in the YAML config
-      if (self.config.useIndexFromUrlPath === true && path.length > 1) {
-        if (path[1] === 'health' || path[1] === 'ping') {
-          res.statusCode = 200
-          res.end('ok\n')
-          return
-        }
-        if (path[1] !== 'github') {
-          res.statusCode = 400
-          res.end('Not a GitHub Webhook.\n')
-          return
-        }
-        if (path[2] && path[2].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])) {
-          token = path[2]
-        }
-        if (path[3] && (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')) {
-          region = path[3]
-        }
+      const self = this
+      let bodyIn = ''
+
+      const { token, region, err } = parseUrlPath({ useIndexFromUrlPath: this.config.useIndexFromUrlPath, path: req.url.split('/') })
+      if (err) {
+        res.statusCode = err.statusCode
+        res.end(err.message)
+        return
       }
+
       req.on('data', function (data) {
         bodyIn += String(data)
       })
       req.on('end', () => {
-        const log = self.parseReq({ headers: req.headers, body: bodyIn })
+        const log = parseReq({ headers: req.headers, bodyJson: bodyIn })
         if (log) {
           self.emitEvent(log, token, region)
         }
+
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.end('OK\n')
       })
@@ -106,70 +93,102 @@ class GitHub {
     }
   }
 
-  parseReq (req) {
-    const body = JSON.parse(req.body)
-    /**
-     * x-github-event" headers that define what data to collect:
-     *
-     * issues
-     * issue_comment
-     * pull_request
-     * pull_request_review
-     * pull_request_review_comment
-     * commit_comment
-     * push
-     * create
-     * delete
-     * release
-     *
-     * add switch based on @event String to generate log fields
-     */
-    /**
-     * URL fields
-     * pull_request.html_url
-     * issue.html_url
-     * repository.html_url
-     * comment.html_url (comment.commit_id, comment.body)
-     */
-    /**
-     * Number fields
-     * pull_request.number
-     * issue.number
-     * repository.url
-     */
-    const event = req.headers['x-github-event']
-    // only send issue and pull request events down the pipeline
-    if (event === 'issues' ||
-      event === 'issue_comment' ||
-      event === 'pull_request' ||
-      event === 'pull_request_review' ||
-      event === 'pull_request_review_comment') {
-      return parseIssueOrPullRequest(event, body)
-    } else if (event === 'commit_comment') {
-      return parseCommitComment(event, body)
-    } else {
-      return null
-    }
-  }
-
   emitEvent (log, token, region) {
-    var context = { name: 'GitHub', sourceName: 'GitHub' }
-    this.addTags(log)
-    if (token) {
-      context.index = token
-    }
-    if (region) {
-      context.region = region
-    }
-    this.eventEmitter.emit('data.object', log, context)
+    const context = { name: 'GitHub', sourceName: 'GitHub' }
+    if (token) { context.index = token }
+    if (region) { context.region = region }
+
+    const tags = this.config.tags
+    const logToEmit = { ...log, tags }
+    this.eventEmitter.emit('data.object', logToEmit, context)
+  }
+}
+
+const parseReq = ({ headers, bodyJson }) => {
+  const body = JSON.parse(bodyJson)
+  /**
+   * x-github-event" headers that define what data to collect:
+   *
+   * [x] issues
+   * [x] issue_comment
+   * [x] pull_request
+   * [x] pull_request_review
+   * [x] pull_request_review_comment
+   * [x] commit_comment
+   * [ ] push
+   * [ ] create
+   * [ ] delete
+   * [ ] release
+   *
+   ********************
+   **   URL fields   **
+   * pull_request.html_url
+   * issue.html_url
+   * repository.html_url
+   * comment.html_url
+   ********************
+   ** Numeral fields **
+   * pull_request.number
+   * issue.number
+   * comment.commit_id
+   * ******************
+   **   Text fields  **
+   * comment.body
+   */
+
+  const event = headers['x-github-event']
+  // only send issue and pull request events down the pipeline
+  if (event === 'issues' ||
+    event === 'issue_comment' ||
+    event === 'pull_request' ||
+    event === 'pull_request_review' ||
+    event === 'pull_request_review_comment') {
+    return parseIssueOrPullRequest(event, body)
+  } else if (event === 'commit_comment') {
+    return parseCommitComment(event, body)
+  } else {
+    return null
+  }
+}
+
+const parseUrlPath = ({ useIndexFromUrlPath, path }) => {
+  // Has to return an object
+
+  if (useIndexFromUrlPath !== true) {
+    return {}
   }
 
-  addTags (log) {
-    if (this.config.tags === undefined) {
-      return
-    }
-    log.tags = this.config.tags
+  if (path.length !== 4) {
+    return { err: { statusCode: 400, message: 'URL Path is invalid. Needs to be in the following format: \'/<WEBHOOK_TYPE>/<TOKEN>/<REGION>\'\n' } }
   }
+
+  if (path[1] === 'health' || path[1] === 'ping') {
+    return { err: { statusCode: 200, message: 'Ok\n' } }
+  }
+
+  if (path[1] !== 'github') {
+    return { err: { statusCode: 400, message: 'Not a GitHub Webhook.\n' } }
+  }
+
+  const urlPath = {
+    token: null,
+    region: null
+  }
+  if (
+    path[2] &&
+    path[2].length > 31 &&
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])
+  ) {
+    urlPath.token = path[2]
+  }
+  if (
+    path[3] &&
+    (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')
+  ) {
+    urlPath.region = path[3]
+  }
+
+  return urlPath
 }
 
 const initEvent = (event, action) => ({

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -17,9 +17,9 @@ GitHub.prototype.start = function () {
     throng({
       workers: this.config.workers,
       lifetime: Infinity
-    }, this.startGitHub.bind(this))
+    }, this.startGitHubWebhookServer.bind(this))
   } else {
-    this.startGitHub(1)
+    this.startGitHubWebhookServer(1)
   }
 }
 
@@ -27,15 +27,26 @@ GitHub.prototype.stop = function (cb) {
   cb()
 }
 
-GitHub.prototype.emitEvent = function (log, token) {
-  var context = { name: 'GitHub', sourceName: 'GitHub', type: 'GitHub Event' }
-  this.addTags(log)
-  if (token) { context.index = token }
-  this.eventEmitter.emit('data.object', log, context)
+GitHub.prototype.startGitHubWebhookServer = function (id) {
+  this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
+  var exitInProgress = false
+  var terminate = function (reason) {
+    return function () {
+      if (exitInProgress) {
+        return
+      }
+      exitInProgress = true
+      consoleLogger.log('Stop GitHub HTTP worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
+      setTimeout(process.exit, 250)
+    }
+  }
+  process.once('SIGTERM', terminate('SIGTERM'))
+  process.once('SIGINT', terminate('SIGINT'))
+  process.once('exit', terminate('exit'))
 }
 
 GitHub.prototype.getHttpServer = function (aport, handler) {
-  var _port = aport || process.env.PORT || 7700
+  var _port = aport || process.env.PORT || 9200
   if (aport === true) {
     _port = process.env.PORT
   }
@@ -50,89 +61,6 @@ GitHub.prototype.getHttpServer = function (aport, handler) {
   }
 }
 
-GitHub.prototype.addTags = function (log) {
-  if (this.config.tags === undefined) {
-    return
-  }
-  log.tags = this.config.tags
-}
-
-GitHub.prototype.parseReq = function (req, token, region) {
-  const self = this
-  const headers = req.headers
-  const event = headers['x-github-event']
-  /**
-   * x-github-event" headers that define what data to collect:
-   *
-   * issues
-   * issue_comment
-   * pull_request
-   * pull_request_review
-   * pull_request_review_comment
-   * push
-   * create
-   * delete
-   * release
-   *
-   * add switch based on @event String to generate log fields
-   */
-
-  const body = JSON.parse(req.body)
-  const { action } = body
-
-  const log = {
-    severity: 'info',
-    title: `GitHub ${event} ${action}`,
-    message: `New event triggered on your repository. It was a ${event} ${action}.`,
-    ...headers,
-    ...body,
-    token,
-    region
-  }
-
-  /**
-   * Needed format
-   */
-
-  /*
-  {
-    "timestamp" : "2014-02-17T15:29:04+0100",
-    "message" : "MyApp on MyHost04 restarted",
-    "severity": "warn",
-    "type" : "server-info"
-  }'
-
-  OR
-
-  {
-    "timestamp" : "2018-02-17T15:58:04+0100",
-    "message" : "Solr 7.0.0 version deployed on prodhost06",
-    "name" : "Solr 7.0.0 deployment",
-    "tags" : ["solr", "7.0.0", "deployment", "upgrade"],
-    "severity": "info",
-    "priority" : "High",
-    "creator" : "John Smith",
-    "type" : "deployment"
-  }'
-
-  OR
-
-  {
-    "timestamp": "2019-05-30T09:58:43.455Z",
-    "creator": "Jenkins",
-    "host": "jenkins-host",
-    "title": "Starting deployment",
-    "message": "Started deployment of Test v1.23 to production",
-    "severity": "info",
-    "type": "deployment",
-    "tags": ["version:1.23", "env:prod"],
-  }
- */
-
-  self.emitEvent(log, token)
-  return log
-}
-
 GitHub.prototype.HttpHandler = function (req, res) {
   try {
     var self = this
@@ -140,6 +68,8 @@ GitHub.prototype.HttpHandler = function (req, res) {
     var path = req.url.split('/')
     var token = null
     var region = null
+
+    // check if the useIndexFromUrlPath param is added in the YAML config
     if (self.config.useIndexFromUrlPath === true && path.length > 1) {
       if (path[1] === 'health' || path[1] === 'ping') {
         res.statusCode = 200
@@ -164,12 +94,10 @@ GitHub.prototype.HttpHandler = function (req, res) {
 
     req.on('data', function (data) {
       bodyIn += String(data)
-      // console.log(data)
     })
 
     req.on('end', function endHandler () {
       self.parseReq({ headers: req.headers, body: bodyIn }, token, region)
-      // send response to client
       res.writeHead(
         200,
         { 'Content-Type': 'text/plain' }
@@ -183,22 +111,97 @@ GitHub.prototype.HttpHandler = function (req, res) {
   }
 }
 
-GitHub.prototype.startGitHub = function (id) {
-  this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
-  var exitInProgress = false
-  var terminate = function (reason) {
-    return function () {
-      if (exitInProgress) {
-        return
-      }
-      exitInProgress = true
-      consoleLogger.log('Stop GitHub HTTP worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
-      setTimeout(process.exit, 250)
-    }
+GitHub.prototype.parseReq = function (req, token, region) {
+  const self = this
+
+  /**
+   * x-github-event" headers that define what data to collect:
+   *
+   * issues
+   * issue_comment
+   * pull_request
+   * pull_request_review
+   * pull_request_review_comment
+   * commit_comment
+   * push
+   * create
+   * delete
+   * release
+   *
+   * add switch based on @event String to generate log fields
+   */
+
+  /**
+   * URL fields
+   * pull_request.url
+   * issue.url
+   * repository.url
+   */
+
+  /**
+   * Number fields
+   * pull_request.number
+   * issue.number
+   * repository.url
+   */
+
+  const event = req.headers['x-github-event']
+
+  // if (
+  //   event !== 'issues' &&
+  //   event !== 'issue_comment' &&
+  //   event !== 'pull_request' &&
+  //   event !== 'pull_request_review' &&
+  //   event !== 'pull_request_review_comment'
+  // ) {
+  //   console.log('should stop')
+  //   // self.stop()
+  // } else {
+  //   console.log('should continue')
+  // }
+
+  // console.log(req.headers)
+  // console.log(JSON.parse(req.body))
+
+  const { action, repository, sender, pull_request: pullRequest, issue } = JSON.parse(req.body)
+
+  const repoName = repository && repository.full_name
+  const repoUrl = repository.html_url
+  const prUrl = pullRequest && pullRequest.html_url
+  const issueUrl = issue && issue.html_url
+  const eventUrl = prUrl || issueUrl
+  const senderUrl = sender && sender.html_url
+  const senderName = sender && sender.login
+  const number = (pullRequest && pullRequest.number) || (issue && issue.number) || null
+
+  const parseMsg = ({ event, action, repoName, repoUrl, senderName, senderUrl, eventUrl, number }) =>
+    `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by [${senderName}](${senderUrl})\n`
+
+  const log = {
+    severity: 'info',
+    type: 'GitHub',
+    title: `Github | ${event} ${action}`,
+    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, eventUrl, number }),
+    region
   }
-  process.once('SIGTERM', terminate('SIGTERM'))
-  process.once('SIGINT', terminate('SIGINT'))
-  process.once('exit', terminate('exit'))
+
+  self.emitEvent(log, token, region)
+  return log
+}
+
+GitHub.prototype.emitEvent = function (log, token, region) {
+  var context = { name: 'GitHub', sourceName: 'GitHub' }
+  this.addTags(log)
+  if (token) { context.index = token }
+  if (region) { context.region = region }
+  this.eventEmitter.emit('data.object', log, context)
+}
+
+GitHub.prototype.addTags = function (log) {
+  if (this.config.tags === undefined) {
+    return
+  }
+  log.tags = this.config.tags
 }
 
 module.exports = GitHub

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -29,25 +29,12 @@ GitHub.prototype.stop = function (cb) {
 }
 
 GitHub.prototype.emitEvent = function (log, token) {
-  var config = this.config
+  // var config = this.config
   var context = { name: 'GitHub', sourceName: 'GitHub' }
   if (token) {
     context.index = token
   }
   this.eventEmitter.emit('data.raw', safeStringify(log), context)
-}
-
-GitHub.prototype.addTags = function (log) {
-  if (this.config.tags === undefined) {
-    return
-  }
-  var keys = Object.keys(this.config.tags)
-  for (var i = 0; i < keys.length; i++) {
-    // avoid setting _index when passed in URL
-    if (log[keys[i]] === undefined) {
-      log[keys[i]] = this.config.tags[keys[i]]
-    }
-  }
 }
 
 GitHub.prototype.getHttpServer = function (aport, handler) {
@@ -59,70 +46,49 @@ GitHub.prototype.getHttpServer = function (aport, handler) {
   try {
     var bindAddress = this.config.bindAddress || '0.0.0.0'
     server = server.listen(_port, bindAddress)
-    consoleLogger.log('Logagent listening (http k8s audit): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
+    consoleLogger.log('Logagent listening (HTTP GitHub): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
     return server
   } catch (err) {
-    consoleLogger.log('Port in use k8s audit (' + _port + '): ' + err)
+    consoleLogger.log('Port in use HTTP GitHub (' + _port + '): ' + err)
   }
 }
 
-GitHub.prototype.parseHeaders = function (headers, token) {
-  var self = this
-  var docs = JSON.parse(body)
-  if (docs.items && docs.items.length > 0) {
-    for (var i = 0; i < docs.items.length; i++) {
-      var log = docs.items[i]
-      log['@timestamp'] = new Date(log.timestamp)
-      self.emitEvent(log, token)
-    }
-  }
-}
+GitHub.prototype.parseReq = function (req, token) {
+  const self = this
+  const headers = JSON.parse(req.headers)
+  const body = JSON.parse(req.body)
+  const log = { ...headers, ...body }
+  consoleLogger.log('log: ', log)
 
-GitHub.prototype.parseBody = function (body, token) {
-  var self = this
-  var docs = JSON.parse(body)
-  if (docs.items && docs.items.length > 0) {
-    for (var i = 0; i < docs.items.length; i++) {
-      var log = docs.items[i]
-      log['@timestamp'] = new Date(log.timestamp)
-      self.emitEvent(log, token)
-    }
-  }
+  self.emitEvent(log, token)
+  return log
 }
 
 GitHub.prototype.HttpHandler = function (req, res) {
   try {
     var self = this
     var bodyIn = ''
-    var path = req.url.split('/')
     var token = null
-    if (self.config.useIndexFromUrlPath === true && path.length > 1) {
-      if (path[1] && path[1].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[1])) {
-        token = path[1]
-      } else if (path[1] === 'health' || path[1] === 'ping') {
-        res.statusCode = 200
-        res.end('ok\n')
-        return
-      }
-    }
+
     req.on('data', function (data) {
       bodyIn += String(data)
-      // onsole.log(data)
+      // console.log(data)
     })
 
     req.on('end', function endHandler () {
-      self.parseBody(bodyIn, token) 
+      const log = self.parseReq({ headers: req.headers, body: bodyIn }, token)
       // send response to client
       res.writeHead(
         200,
         { 'Content-Type': 'text/plain' }
       )
-      res.end('OK\n')
+      // res.end('OK\n')
+      res.end(safeStringify(log))
     })
   } catch (err) {
     res.statusCode = 500
     res.end()
-    consoleLogger.error('Error in Kubernetes Audit HttpHandler: ' + err)
+    consoleLogger.error('Error in GitHub HttpHandler: ' + err)
   }
 }
 
@@ -135,7 +101,7 @@ GitHub.prototype.startGitHub = function (id) {
         return
       }
       exitInProgress = true
-      consoleLogger.log('Stop k8s audit http worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
+      consoleLogger.log('Stop GitHub HTTP worker: ' + id + ', pid:' + process.pid + ', terminate reason: ' + reason + ' memory rss: ' + (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) + ' MB')
       setTimeout(process.exit, 250)
     }
   }
@@ -145,5 +111,3 @@ GitHub.prototype.startGitHub = function (id) {
 }
 
 module.exports = GitHub
-
-

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -147,21 +147,21 @@ GitHub.prototype.parseReq = function (req, token, region) {
 
   const event = req.headers['x-github-event']
 
-  // if (
-  //   event !== 'issues' &&
-  //   event !== 'issue_comment' &&
-  //   event !== 'pull_request' &&
-  //   event !== 'pull_request_review' &&
-  //   event !== 'pull_request_review_comment'
-  // ) {
-  //   console.log('should stop')
-  //   // self.stop()
-  // } else {
-  //   console.log('should continue')
-  // }
+  if (
+    event !== 'issues' &&
+    event !== 'issue_comment' &&
+    event !== 'pull_request' &&
+    event !== 'pull_request_review' &&
+    event !== 'pull_request_review_comment'
+  ) {
+    console.log('should stop')
+    // self.stop()
+  } else {
+    console.log('should continue')
+  }
 
-  // console.log(req.headers)
-  // console.log(JSON.parse(req.body))
+  console.log(req.headers)
+  console.log(JSON.parse(req.body))
 
   const { action, repository, sender, pull_request: pullRequest, issue } = JSON.parse(req.body)
 
@@ -172,16 +172,17 @@ GitHub.prototype.parseReq = function (req, token, region) {
   const eventUrl = prUrl || issueUrl
   const senderUrl = sender && sender.html_url
   const senderName = sender && sender.login
+  const senderAvatarUrl = sender && sender.avatar_url
   const number = (pullRequest && pullRequest.number) || (issue && issue.number) || null
 
-  const parseMsg = ({ event, action, repoName, repoUrl, senderName, senderUrl, eventUrl, number }) =>
-    `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by [${senderName}](${senderUrl})\n`
+  const parseMsg = ({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number }) =>
+    `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
 
   const log = {
     severity: 'info',
     type: 'GitHub',
     title: `Github | ${event} ${action}`,
-    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, eventUrl, number }),
+    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number }),
     region
   }
 

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -28,14 +28,9 @@ GitHub.prototype.stop = function (cb) {
 }
 
 GitHub.prototype.emitEvent = function (log, token) {
-  this.addTags(log)
-  if (token) {
-    log['_index'] = token
-  }
   var context = { name: 'GitHub', sourceName: 'GitHub', type: 'GitHub Event' }
-  if (token) {
-    context.index = token
-  }
+  this.addTags(log)
+  if (token) { context.index = token }
   this.eventEmitter.emit('data.object', log, context)
 }
 
@@ -62,7 +57,7 @@ GitHub.prototype.addTags = function (log) {
   log.tags = this.config.tags
 }
 
-GitHub.prototype.parseReq = function (req, token) {
+GitHub.prototype.parseReq = function (req, token, region) {
   const self = this
   const headers = req.headers
   const event = headers['x-github-event']
@@ -90,7 +85,9 @@ GitHub.prototype.parseReq = function (req, token) {
     title: `GitHub ${event} ${action}`,
     message: `New event triggered on your repository. It was a ${event} ${action}.`,
     ...headers,
-    ...body
+    ...body,
+    token,
+    region
   }
 
   /**
@@ -140,7 +137,30 @@ GitHub.prototype.HttpHandler = function (req, res) {
   try {
     var self = this
     var bodyIn = ''
+    var path = req.url.split('/')
     var token = null
+    var region = null
+    if (self.config.useIndexFromUrlPath === true && path.length > 1) {
+      if (path[1] === 'health' || path[1] === 'ping') {
+        res.statusCode = 200
+        res.end('ok\n')
+        return
+      }
+
+      if (path[1] !== 'github') {
+        res.statusCode = 400
+        res.end('Not a GitHub Webhook.\n')
+        return
+      }
+
+      if (path[2] && path[2].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])) {
+        token = path[2]
+      }
+
+      if (path[3] && (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')) {
+        region = path[3]
+      }
+    }
 
     req.on('data', function (data) {
       bodyIn += String(data)
@@ -148,7 +168,7 @@ GitHub.prototype.HttpHandler = function (req, res) {
     })
 
     req.on('end', function endHandler () {
-      self.parseReq({ headers: req.headers, body: bodyIn }, token)
+      self.parseReq({ headers: req.headers, body: bodyIn }, token, region)
       // send response to client
       res.writeHead(
         200,

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -1,6 +1,5 @@
 var consoleLogger = require('../../util/logger.js')
 var http = require('http')
-var safeStringify = require('fast-safe-stringify')
 var throng = require('throng')
 
 function GitHub (config, eventEmitter) {
@@ -34,7 +33,7 @@ GitHub.prototype.emitEvent = function (log, token) {
   if (token) {
     context.index = token
   }
-  this.eventEmitter.emit('data.raw', safeStringify(log), context)
+  this.eventEmitter.emit('data.object', log, context)
 }
 
 GitHub.prototype.getHttpServer = function (aport, handler) {
@@ -89,11 +88,11 @@ GitHub.prototype.parseReq = function (req, token) {
   const { action } = body
 
   const log = {
-    ...headers,
-    ...body,
     severity: 'info',
     title: `GitHub ${event} ${action}`,
-    message: `New event triggered on your repository. It was a ${event} ${action}.`
+    message: `New event triggered on your repository. It was a ${event} ${action}.`,
+    ...headers,
+    ...body
   }
 
   /**

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -114,7 +114,62 @@ GitHub.prototype.HttpHandler = function (req, res) {
   }
 }
 
+const initEvent = (event, action) => ({
+  severity: 'info',
+  type: 'GitHub',
+  title: `Github | ${event} ${action}`
+})
+
+const parseIssueOrPullRequest = (event, body) => {
+  const {
+    action,
+    repository,
+    sender,
+    pull_request: pullRequest,
+    issue
+  } = body
+
+  const repoName = repository && repository.full_name
+  const repoUrl = repository.html_url
+  const prUrl = pullRequest && pullRequest.html_url
+  const issueUrl = issue && issue.html_url
+  const eventUrl = prUrl || issueUrl
+  const senderUrl = sender && sender.html_url
+  const senderName = sender && sender.login
+  const senderAvatarUrl = sender && sender.avatar_url
+  const number = (pullRequest && pullRequest.number) || (issue && issue.number) || null
+
+  return {
+    ...initEvent(event, action),
+    message: `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
+  }
+}
+
+const parseCommitComment = (event, body) => {
+  const {
+    action,
+    repository,
+    sender,
+    comment
+  } = body
+
+  const repoName = repository && repository.full_name
+  const repoUrl = repository.html_url
+  const senderUrl = sender && sender.html_url
+  const senderName = sender && sender.login
+  const senderAvatarUrl = sender && sender.avatar_url
+  const commitId = comment && comment.commit_id
+  const commitUrl = comment && comment.html_url
+  const commitMessage = comment && comment.body
+
+  return {
+    ...initEvent(event, action),
+    message: `#### [[${repoName}](${repoUrl})] - [${event} (${commitId})](${commitUrl}) "${commitMessage}" ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
+  }
+}
+
 GitHub.prototype.parseReq = function (req) {
+  const body = JSON.parse(req.body)
   /**
    * x-github-event" headers that define what data to collect:
    *
@@ -141,65 +196,29 @@ GitHub.prototype.parseReq = function (req) {
    */
 
   /**
-   * Numeral fields
+   * Number fields
    * pull_request.number
    * issue.number
-   * commit.commit_id
+   * repository.url
    */
 
   const event = req.headers['x-github-event']
-
   // only send issue and pull request events down the pipeline
   if (
-    !(event === 'issues' ||
+    event === 'issues' ||
     event === 'issue_comment' ||
     event === 'pull_request' ||
     event === 'pull_request_review' ||
-    event === 'pull_request_review_comment')
+    event === 'pull_request_review_comment'
   ) {
-    return
+    return parseIssueOrPullRequest(event, body)
+  } else if (
+    event === 'commit_comment'
+  ) {
+    return parseCommitComment(event, body)
+  } else {
+    return null
   }
-
-  const {
-    action,
-    repository: {
-      full_name: repoName,
-      html_url: repoUrl
-    },
-    sender: {
-      html_url: senderUrl,
-      login: senderName,
-      avatar_url: senderAvatarUrl
-    },
-    pull_request: {
-      html_url: prUrl,
-      number: prNumber
-    },
-    issue: {
-      html_url: issueUrl,
-      number: issueNumber
-    }
-    // comment: {
-    //   commit_id: commitId,
-    //   html_url: commitUrl,
-    //   body: commitMessage
-    // }
-  } = JSON.parse(req.body)
-
-  const eventUrl = prUrl || issueUrl
-  const number = prNumber || issueNumber
-
-  const parseMsg = ({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number }) =>
-    `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
-
-  const log = {
-    severity: 'info',
-    type: 'GitHub',
-    title: `Github | ${event} ${action}`,
-    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number })
-  }
-
-  return log
 }
 
 GitHub.prototype.emitEvent = function (log, token, region) {

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -29,6 +29,9 @@ GitHub.prototype.stop = function (cb) {
 
 GitHub.prototype.emitEvent = function (log, token) {
   this.addTags(log)
+  if (token) {
+    log['_index'] = token
+  }
   var context = { name: 'GitHub', sourceName: 'GitHub', type: 'GitHub Event' }
   if (token) {
     context.index = token
@@ -56,12 +59,7 @@ GitHub.prototype.addTags = function (log) {
   if (this.config.tags === undefined) {
     return
   }
-  var keys = Object.keys(this.config.tags)
-  for (var i = 0; i < keys.length; i++) {
-    if (log[keys[i]] === undefined) {
-      log[keys[i]] = this.config.tags[keys[i]]
-    }
-  }
+  log.tags = this.config.tags
 }
 
 GitHub.prototype.parseReq = function (req, token) {

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -38,7 +38,7 @@ GitHub.prototype.emitEvent = function (log, token) {
 }
 
 GitHub.prototype.getHttpServer = function (aport, handler) {
-  var _port = aport || process.env.PORT || 9200
+  var _port = aport || process.env.PORT || 7700
   if (aport === true) {
     _port = process.env.PORT
   }
@@ -57,8 +57,34 @@ GitHub.prototype.parseReq = function (req, token) {
   const self = this
   const headers = JSON.parse(req.headers)
   const body = JSON.parse(req.body)
-  const log = { ...headers, ...body }
+  const log = { ...headers, ...body, '@timestamp': new Date() }
   consoleLogger.log('log: ', log)
+
+  /**
+   * Needed format
+   */
+
+  /*
+  {
+    "timestamp" : "2014-02-17T15:29:04+0100",
+    "message" : "MyApp on MyHost04 restarted",
+    "severity": "warn",
+    "type" : "server-info"
+  }'
+
+  OR
+
+  {
+    "timestamp" : "2018-02-17T15:58:04+0100",
+    "message" : "Solr 7.0.0 version deployed on prodhost06",
+    "name" : "Solr 7.0.0 deployment",
+    "tags" : ["solr", "7.0.0", "deployment", "upgrade"],
+    "severity": "info",
+    "priority" : "High",
+    "creator" : "John Smith",
+    "type" : "deployment"
+  }'
+ */
 
   self.emitEvent(log, token)
   return log

--- a/lib/plugins/input/github.js
+++ b/lib/plugins/input/github.js
@@ -97,7 +97,10 @@ GitHub.prototype.HttpHandler = function (req, res) {
     })
 
     req.on('end', function endHandler () {
-      self.parseReq({ headers: req.headers, body: bodyIn }, token, region)
+      const log = self.parseReq({ headers: req.headers, body: bodyIn })
+      if (log) {
+        self.emitEvent(log, token, region)
+      }
       res.writeHead(
         200,
         { 'Content-Type': 'text/plain' }
@@ -111,9 +114,7 @@ GitHub.prototype.HttpHandler = function (req, res) {
   }
 }
 
-GitHub.prototype.parseReq = function (req, token, region) {
-  const self = this
-
+GitHub.prototype.parseReq = function (req) {
   /**
    * x-github-event" headers that define what data to collect:
    *
@@ -133,47 +134,60 @@ GitHub.prototype.parseReq = function (req, token, region) {
 
   /**
    * URL fields
-   * pull_request.url
-   * issue.url
-   * repository.url
+   * pull_request.html_url
+   * issue.html_url
+   * repository.html_url
+   * comment.html_url (comment.commit_id, comment.body)
    */
 
   /**
-   * Number fields
+   * Numeral fields
    * pull_request.number
    * issue.number
-   * repository.url
+   * commit.commit_id
    */
 
   const event = req.headers['x-github-event']
 
+  // only send issue and pull request events down the pipeline
   if (
-    event !== 'issues' &&
-    event !== 'issue_comment' &&
-    event !== 'pull_request' &&
-    event !== 'pull_request_review' &&
-    event !== 'pull_request_review_comment'
+    !(event === 'issues' ||
+    event === 'issue_comment' ||
+    event === 'pull_request' ||
+    event === 'pull_request_review' ||
+    event === 'pull_request_review_comment')
   ) {
-    console.log('should stop')
-    // self.stop()
-  } else {
-    console.log('should continue')
+    return
   }
 
-  console.log(req.headers)
-  console.log(JSON.parse(req.body))
+  const {
+    action,
+    repository: {
+      full_name: repoName,
+      html_url: repoUrl
+    },
+    sender: {
+      html_url: senderUrl,
+      login: senderName,
+      avatar_url: senderAvatarUrl
+    },
+    pull_request: {
+      html_url: prUrl,
+      number: prNumber
+    },
+    issue: {
+      html_url: issueUrl,
+      number: issueNumber
+    }
+    // comment: {
+    //   commit_id: commitId,
+    //   html_url: commitUrl,
+    //   body: commitMessage
+    // }
+  } = JSON.parse(req.body)
 
-  const { action, repository, sender, pull_request: pullRequest, issue } = JSON.parse(req.body)
-
-  const repoName = repository && repository.full_name
-  const repoUrl = repository.html_url
-  const prUrl = pullRequest && pullRequest.html_url
-  const issueUrl = issue && issue.html_url
   const eventUrl = prUrl || issueUrl
-  const senderUrl = sender && sender.html_url
-  const senderName = sender && sender.login
-  const senderAvatarUrl = sender && sender.avatar_url
-  const number = (pullRequest && pullRequest.number) || (issue && issue.number) || null
+  const number = prNumber || issueNumber
 
   const parseMsg = ({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number }) =>
     `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
@@ -182,11 +196,9 @@ GitHub.prototype.parseReq = function (req, token, region) {
     severity: 'info',
     type: 'GitHub',
     title: `Github | ${event} ${action}`,
-    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number }),
-    region
+    message: parseMsg({ event, action, repoName, repoUrl, senderName, senderUrl, senderAvatarUrl, eventUrl, number })
   }
 
-  self.emitEvent(log, token, region)
   return log
 }
 

--- a/lib/plugins/input/journaldUpload.js
+++ b/lib/plugins/input/journaldUpload.js
@@ -147,7 +147,7 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
     })
 
     req.on('end', function endHandler () {
-      self.parseBody(bodyIn, token)   
+      self.parseBody(bodyIn, token)
       // send response to client
       res.writeHead(
         200,

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -122,7 +122,7 @@ const parseReq = ({ headers, bodyIn }) => {
    * [x] pull_request_review
    * [x] pull_request_review_comment
    * [x] commit_comment
-   * [ ] push
+   * [x] push
    * [ ] create
    * [ ] delete
    * [ ] release
@@ -147,6 +147,8 @@ const parseReq = ({ headers, bodyIn }) => {
     return parseIssueOrPullRequest(event, body)
   } else if (event === 'commit_comment') {
     return parseCommitComment(event, body)
+  } else if (event === 'push') {
+    return parsePush(event, body)
   } else {
     return null
   }
@@ -241,7 +243,63 @@ const parseCommitComment = (event, body) => {
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${repoUrl})]\n[${event} (${commit.id})](${commit.url}) "${commit.message}" ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
+    message: `#### [[${repoName}](${repoUrl})]\n[${event} (${commit.id})](${commit.url}) ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
+  }
+}
+
+const parsePush = (event, body) => {
+  const {
+    ref,
+    commits,
+    head_commit: headCommit,
+    repository,
+    sender
+  } = body
+  const {
+    repoName,
+    repoUrl
+  } = parseRepo(repository)
+  const {
+    senderUrl,
+    senderName,
+    senderAvatarUrl
+  } = parseSender(sender)
+
+  const generatePushEvent = ({ event, pushTo, repoName, url, commitsCount, headCommitUrl, refName, senderAvatarUrl, senderName, senderUrl }) => ({
+    ...initEvent({ event, action: pushTo, webhookName: 'GitHub' }),
+    message: `#### [[${repoName}](${url})]\nPushed [${commitsCount} commit(s)](${headCommitUrl}) to ${pushTo} ${refName} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
+  })
+
+  const refSplit = ref.split('/')
+  const refType = refSplit[1]
+  const refName = refSplit[2]
+
+  if (refType === 'heads') {
+    return generatePushEvent({
+      event,
+      pushTo: 'branch',
+      repoName,
+      url: `${repoUrl}/tree/${refName}`,
+      commitsCount: commits.length,
+      headCommitUrl: headCommit.url,
+      refName,
+      senderAvatarUrl,
+      senderName,
+      senderUrl
+    })
+  } else if (refType === 'tags') {
+    return generatePushEvent({
+      event,
+      pushTo: 'tag',
+      repoName,
+      url: `${repoUrl}/releases/tag/${refName}`,
+      commitsCount: commits.length,
+      headCommitUrl: headCommit.url,
+      refName,
+      senderAvatarUrl,
+      senderName,
+      senderUrl
+    })
   }
 }
 

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -1,6 +1,7 @@
-const consoleLogger = require('../../util/logger.js')
 const http = require('http')
 const throng = require('throng')
+const consoleLogger = require('../../../util/logger.js')
+const { parseUrlPath, initEvent } = require('./util')
 
 class GitHub {
   constructor (config, eventEmitter) {
@@ -29,7 +30,7 @@ class GitHub {
   }
 
   startGitHubWebhookServer (id) {
-    this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
+    this.getHttpServer(Number(this.config.port), this.httpHandler.bind(this))
     let exitInProgress = false
     const terminate = function (reason) {
       return function () {
@@ -62,12 +63,21 @@ class GitHub {
     }
   }
 
-  HttpHandler (req, res) {
+  httpHandler (req, res) {
     try {
       const self = this
       let bodyIn = ''
 
-      const { token, region, err } = parseUrlPath({ useIndexFromUrlPath: this.config.useIndexFromUrlPath, path: req.url.split('/') })
+      const {
+        token,
+        region,
+        err
+      } = parseUrlPath({
+        useIndexFromUrlPath: this.config.useIndexFromUrlPath,
+        path: req.url.split('/'),
+        webhookName: 'github'
+      })
+
       if (err) {
         res.statusCode = err.statusCode
         res.end(err.message)
@@ -105,7 +115,6 @@ class GitHub {
 }
 
 const parseReq = ({ headers, bodyJson }) => {
-  const body = JSON.parse(bodyJson)
   /**
    * x-github-event" headers that define what data to collect:
    *
@@ -121,21 +130,9 @@ const parseReq = ({ headers, bodyJson }) => {
    * [ ] release
    *
    ********************
-   **   URL fields   **
-   * pull_request.html_url
-   * issue.html_url
-   * repository.html_url
-   * comment.html_url
-   ********************
-   ** Numeral fields **
-   * pull_request.number
-   * issue.number
-   * comment.commit_id
-   * ******************
-   **   Text fields  **
-   * comment.body
    */
 
+  const body = JSON.parse(bodyJson)
   const event = headers['x-github-event']
   // only send issue and pull request events down the pipeline
   if (event === 'issues' ||
@@ -151,51 +148,28 @@ const parseReq = ({ headers, bodyJson }) => {
   }
 }
 
-const parseUrlPath = ({ useIndexFromUrlPath, path }) => {
-  // Has to return an object
-
-  if (useIndexFromUrlPath !== true) {
+const parseRepo = (repository) => {
+  if (!repository) {
     return {}
   }
 
-  if (path.length !== 4) {
-    return { err: { statusCode: 400, message: 'URL Path is invalid. Needs to be in the following format: \'/<WEBHOOK_TYPE>/<TOKEN>/<REGION>\'\n' } }
+  return {
+    repoName: repository.full_name,
+    repoUrl: repository.html_url
   }
-
-  if (path[1] === 'health' || path[1] === 'ping') {
-    return { err: { statusCode: 200, message: 'Ok\n' } }
-  }
-
-  if (path[1] !== 'github') {
-    return { err: { statusCode: 400, message: 'Not a GitHub Webhook.\n' } }
-  }
-
-  const urlPath = {
-    token: null,
-    region: null
-  }
-  if (
-    path[2] &&
-    path[2].length > 31 &&
-    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])
-  ) {
-    urlPath.token = path[2]
-  }
-  if (
-    path[3] &&
-    (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')
-  ) {
-    urlPath.region = path[3]
-  }
-
-  return urlPath
 }
 
-const initEvent = (event, action) => ({
-  severity: 'info',
-  type: 'GitHub',
-  title: `Github | ${event} ${action}`
-})
+const parseSender = (sender) => {
+  if (!sender) {
+    return {}
+  }
+
+  return {
+    senderUrl: sender.html_url,
+    senderName: sender.login,
+    senderAvatarUrl: sender.avatar_url
+  }
+}
 
 const parseIssueOrPullRequest = (event, body) => {
   const {
@@ -205,19 +179,27 @@ const parseIssueOrPullRequest = (event, body) => {
     pull_request: pullRequest,
     issue
   } = body
+  if (!(issue || pullRequest)) {
+    return
+  }
 
-  const repoName = repository && repository.full_name
-  const repoUrl = repository.html_url
-  const prUrl = pullRequest && pullRequest.html_url
-  const issueUrl = issue && issue.html_url
+  const {
+    repoName,
+    repoUrl
+  } = parseRepo(repository)
+  const {
+    senderUrl,
+    senderName,
+    senderAvatarUrl
+  } = parseSender(sender)
+
+  const prUrl = pullRequest.html_url
+  const issueUrl = issue.html_url
   const eventUrl = prUrl || issueUrl
-  const senderUrl = sender && sender.html_url
-  const senderName = sender && sender.login
-  const senderAvatarUrl = sender && sender.avatar_url
-  const number = (pullRequest && pullRequest.number) || (issue && issue.number) || null
+  const number = pullRequest.number || issue.number || null
 
   return {
-    ...initEvent(event, action),
+    ...initEvent({ event, action, webhookName: 'GitHub' }),
     message: `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
   }
 }
@@ -229,19 +211,29 @@ const parseCommitComment = (event, body) => {
     sender,
     comment
   } = body
+  if (!comment) {
+    return
+  }
 
-  const repoName = repository && repository.full_name
-  const repoUrl = repository.html_url
-  const senderUrl = sender && sender.html_url
-  const senderName = sender && sender.login
-  const senderAvatarUrl = sender && sender.avatar_url
-  const commitId = comment && comment.commit_id
-  const commitUrl = comment && comment.html_url
-  const commitMessage = comment && comment.body
+  const {
+    repoName,
+    repoUrl
+  } = parseRepo(repository)
+  const {
+    senderUrl,
+    senderName,
+    senderAvatarUrl
+  } = parseSender(sender)
+
+  const commit = {
+    id: comment.commit_id,
+    url: comment.html_url,
+    message: comment.body
+  }
 
   return {
-    ...initEvent(event, action),
-    message: `#### [[${repoName}](${repoUrl})] - [${event} (${commitId})](${commitUrl}) "${commitMessage}" ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
+    ...initEvent({ event, action, webhookName: 'GitHub' }),
+    message: `#### [[${repoName}](${repoUrl})] - [${event} (${commit.id})](${commit.url}) "${commit.message}" ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
   }
 }
 

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -300,8 +300,6 @@ const parseRelease = (event, body) => {
     return
   }
 
-  console.log(body)
-
   const {
     repoName,
     repoUrl

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -70,7 +70,6 @@ class GitHub {
 
       const {
         token,
-        region,
         err
       } = parseUrlPath({
         useIndexFromUrlPath: this.config.useIndexFromUrlPath,
@@ -90,7 +89,7 @@ class GitHub {
       req.on('end', () => {
         const log = parseReq({ headers: req.headers, bodyIn })
         if (log) {
-          self.emitEvent(log, token, region)
+          self.emitEvent(log, token)
         }
 
         res.writeHead(200, { 'Content-Type': 'text/plain' })
@@ -103,10 +102,9 @@ class GitHub {
     }
   }
 
-  emitEvent (log, token, region) {
+  emitEvent (log, token) {
     const context = { name: 'GitHub', sourceName: 'GitHub' }
     if (token) { context.index = token }
-    if (region) { context.region = region }
 
     const tags = this.config.tags
     const logToEmit = { ...log, tags }
@@ -210,7 +208,7 @@ const parseIssueOrPullRequest = (event, body) => {
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${repoUrl})] - [${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
+    message: `#### [[${repoName}](${repoUrl})]\n[${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
   }
 }
 
@@ -243,7 +241,7 @@ const parseCommitComment = (event, body) => {
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${repoUrl})] - [${event} (${commit.id})](${commit.url}) "${commit.message}" ${action} by ![](${senderAvatarUrl}&s=32) [${senderName}](${senderUrl})\n`
+    message: `#### [[${repoName}](${repoUrl})]\n[${event} (${commit.id})](${commit.url}) "${commit.message}" ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
   }
 }
 

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -88,7 +88,7 @@ class GitHub {
         bodyIn += String(data)
       })
       req.on('end', () => {
-        const log = parseReq({ headers: req.headers, bodyJson: bodyIn })
+        const log = parseReq({ headers: req.headers, bodyIn })
         if (log) {
           self.emitEvent(log, token, region)
         }
@@ -114,7 +114,7 @@ class GitHub {
   }
 }
 
-const parseReq = ({ headers, bodyJson }) => {
+const parseReq = ({ headers, bodyIn }) => {
   /**
    * x-github-event" headers that define what data to collect:
    *
@@ -132,7 +132,13 @@ const parseReq = ({ headers, bodyJson }) => {
    ********************
    */
 
-  const body = JSON.parse(bodyJson)
+  const parseGithubEventApiResponseBody = (bodyIn) => {
+    const decodedBody = decodeURIComponent(bodyIn)
+    const decodedBodyWithoutPayload = decodedBody.replace('payload=', '')
+    return JSON.parse(decodedBodyWithoutPayload)
+  }
+
+  const body = parseGithubEventApiResponseBody(bodyIn)
   const event = headers['x-github-event']
   // only send issue and pull request events down the pipeline
   if (event === 'issues' ||
@@ -193,10 +199,14 @@ const parseIssueOrPullRequest = (event, body) => {
     senderAvatarUrl
   } = parseSender(sender)
 
-  const prUrl = pullRequest.html_url
-  const issueUrl = issue.html_url
+  const prUrl = pullRequest && pullRequest.html_url
+  const prNumber = pullRequest && pullRequest.number
+
+  const issueUrl = issue && issue.html_url
+  const issueNumber = issue && issue.number
+
   const eventUrl = prUrl || issueUrl
-  const number = pullRequest.number || issue.number || null
+  const number = prNumber || issueNumber || null
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),

--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -1,7 +1,12 @@
 const http = require('http')
 const throng = require('throng')
 const consoleLogger = require('../../../util/logger.js')
-const { parseUrlPath, initEvent } = require('./util')
+const {
+  parseUrlPath,
+  initEvent,
+  initAuthorMessage,
+  initRepoMessage
+} = require('./util')
 
 class GitHub {
   constructor (config, eventEmitter) {
@@ -125,7 +130,7 @@ const parseReq = ({ headers, bodyIn }) => {
    * [x] push
    * [ ] create
    * [ ] delete
-   * [ ] release
+   * [x] release
    *
    ********************
    */
@@ -149,6 +154,8 @@ const parseReq = ({ headers, bodyIn }) => {
     return parseCommitComment(event, body)
   } else if (event === 'push') {
     return parsePush(event, body)
+  } else if (event === 'release') {
+    return parseRelease(event, body)
   } else {
     return null
   }
@@ -210,7 +217,7 @@ const parseIssueOrPullRequest = (event, body) => {
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${repoUrl})]\n[${event} #${number}](${eventUrl}) ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
+    message: `#### ${initRepoMessage({ repoName, repoUrl })}\n[${event} #${number}](${eventUrl}) ${action} by ${initAuthorMessage({ senderUrl, senderName, senderAvatarUrl })}\n`
   }
 }
 
@@ -243,7 +250,7 @@ const parseCommitComment = (event, body) => {
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${repoUrl})]\n[${event} (${commit.id})](${commit.url}) ${action} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
+    message: `#### ${initRepoMessage({ repoName, repoUrl })}\n[${event} (${commit.id})](${commit.url}) ${action} by ${initAuthorMessage({ senderUrl, senderName, senderAvatarUrl })}\n`
   }
 }
 
@@ -255,6 +262,15 @@ const parsePush = (event, body) => {
     repository,
     sender
   } = body
+
+  const {
+    1: refType,
+    2: refName
+  } = ref.split('/')
+  if (refType !== 'heads') {
+    return
+  }
+
   const {
     repoName,
     repoUrl
@@ -265,41 +281,45 @@ const parsePush = (event, body) => {
     senderAvatarUrl
   } = parseSender(sender)
 
-  const generatePushEvent = ({ event, pushTo, repoName, url, commitsCount, headCommitUrl, refName, senderAvatarUrl, senderName, senderUrl }) => ({
-    ...initEvent({ event, action: pushTo, webhookName: 'GitHub' }),
-    message: `#### [[${repoName}](${url})]\nPushed [${commitsCount} commit(s)](${headCommitUrl}) to ${pushTo} ${refName} by ![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})\n`
-  })
+  const branchUrl = `${repoUrl}/tree/${refName}`
 
-  const refSplit = ref.split('/')
-  const refType = refSplit[1]
-  const refName = refSplit[2]
+  return {
+    ...initEvent({ event, action: 'branch', webhookName: 'GitHub' }),
+    message: `#### ${initRepoMessage({ repoName, repoUrl })}\n[${commits.length} commit(s)](${headCommit.url}) pushed to branch [${refName}](${branchUrl}) by ${initAuthorMessage({ senderUrl, senderName, senderAvatarUrl })}\n`
+  }
+}
 
-  if (refType === 'heads') {
-    return generatePushEvent({
-      event,
-      pushTo: 'branch',
-      repoName,
-      url: `${repoUrl}/tree/${refName}`,
-      commitsCount: commits.length,
-      headCommitUrl: headCommit.url,
-      refName,
-      senderAvatarUrl,
-      senderName,
-      senderUrl
-    })
-  } else if (refType === 'tags') {
-    return generatePushEvent({
-      event,
-      pushTo: 'tag',
-      repoName,
-      url: `${repoUrl}/releases/tag/${refName}`,
-      commitsCount: commits.length,
-      headCommitUrl: headCommit.url,
-      refName,
-      senderAvatarUrl,
-      senderName,
-      senderUrl
-    })
+const parseRelease = (event, body) => {
+  const {
+    action,
+    repository,
+    sender,
+    release
+  } = body
+  if (!release) {
+    return
+  }
+
+  console.log(body)
+
+  const {
+    repoName,
+    repoUrl
+  } = parseRepo(repository)
+  const {
+    senderUrl,
+    senderName,
+    senderAvatarUrl
+  } = parseSender(sender)
+
+  const {
+    html_url: url,
+    tag_name: tag
+  } = release
+
+  return {
+    ...initEvent({ event, action, webhookName: 'GitHub' }),
+    message: `#### ${initRepoMessage({ repoName, repoUrl })}\n[${event} (${tag})](${url}) ${action} by ${initAuthorMessage({ senderUrl, senderName, senderAvatarUrl })}\n`
   }
 }
 

--- a/lib/plugins/input/webhooks/util.js
+++ b/lib/plugins/input/webhooks/util.js
@@ -5,8 +5,8 @@ const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
     return {}
   }
 
-  if (path.length !== 4) {
-    return { err: { statusCode: 400, message: 'URL Path is invalid. Needs to be in the following format: \'/<WEBHOOK_TYPE>/<TOKEN>/<REGION>\'\n' } }
+  if (path.length !== 3) {
+    return { err: { statusCode: 400, message: 'URL Path is invalid. Needs to be in the following format: \'/<WEBHOOK_TYPE>/<TOKEN>\'\n' } }
   }
 
   if (path[1] === 'health' || path[1] === 'ping') {
@@ -18,8 +18,7 @@ const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
   }
 
   const urlPath = {
-    token: null,
-    region: null
+    token: null
   }
   if (
     path[2] &&
@@ -27,12 +26,6 @@ const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
     /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])
   ) {
     urlPath.token = path[2]
-  }
-  if (
-    path[3] &&
-    (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')
-  ) {
-    urlPath.region = path[3]
   }
 
   return urlPath

--- a/lib/plugins/input/webhooks/util.js
+++ b/lib/plugins/input/webhooks/util.js
@@ -1,0 +1,50 @@
+const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
+  // Has to return an object
+
+  if (useIndexFromUrlPath !== true) {
+    return {}
+  }
+
+  if (path.length !== 4) {
+    return { err: { statusCode: 400, message: 'URL Path is invalid. Needs to be in the following format: \'/<WEBHOOK_TYPE>/<TOKEN>/<REGION>\'\n' } }
+  }
+
+  if (path[1] === 'health' || path[1] === 'ping') {
+    return { err: { statusCode: 200, message: 'Ok\n' } }
+  }
+
+  if (path[1] !== (webhookName && webhookName.toLowerCase())) {
+    return { err: { statusCode: 400, message: `Not a ${webhookName} Webhook.\n` } }
+  }
+
+  const urlPath = {
+    token: null,
+    region: null
+  }
+  if (
+    path[2] &&
+    path[2].length > 31 &&
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])
+  ) {
+    urlPath.token = path[2]
+  }
+  if (
+    path[3] &&
+    (path[3].toLowerCase() === 'us' || path[3].toLowerCase() === 'eu')
+  ) {
+    urlPath.region = path[3]
+  }
+
+  return urlPath
+}
+
+const initEvent = ({ event, action, webhookName }) => ({
+  severity: 'info',
+  type: webhookName,
+  title: `${webhookName} | ${event} ${action}`
+})
+
+module.exports = {
+  parseUrlPath,
+  initEvent
+}

--- a/lib/plugins/input/webhooks/util.js
+++ b/lib/plugins/input/webhooks/util.js
@@ -34,10 +34,23 @@ const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
 const initEvent = ({ event, action, webhookName }) => ({
   severity: 'info',
   type: webhookName,
-  title: `${webhookName} | ${event} ${action}`
+  title: `${webhookName} | ${capitalize(event)} ${capitalize(action)}`
 })
+
+const initRepoMessage = ({ repoName, repoUrl }) =>
+  `[[${repoName}](${repoUrl})]`
+
+const initAuthorMessage = ({ senderAvatarUrl, senderName, senderUrl }) =>
+  `![](${senderAvatarUrl}&s=25) [${senderName}](${senderUrl})`
+
+const capitalize = (s) => {
+  if (typeof s !== 'string') return ''
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
 
 module.exports = {
   parseUrlPath,
-  initEvent
+  initEvent,
+  initAuthorMessage,
+  initRepoMessage
 }

--- a/lib/plugins/output/output-http.js
+++ b/lib/plugins/output/output-http.js
@@ -1,8 +1,6 @@
 'use strict'
 var consoleLogger = require('../../util/logger.js')
-var flatten = require('flat')
 var request = require('requestretry')
-var os = require('os')
 /** example configuration
   output:
     module: output-http
@@ -46,15 +44,6 @@ function OutputHttp (config, eventEmitter) {
   if (this.config.flushInterval < 0.5) {
     // don't allow more than 2 requests per second
     this.config.flushInterval = 1
-  }
-  if (!this.config.tags) {
-    this.config.tags = {
-      os: {
-        host: os.hostname()
-      }
-    }
-  } else {
-    this.config.tags.os = { host: os.hostname() }
   }
 }
 module.exports = OutputHttp

--- a/lib/plugins/output/output-sematext-events.js
+++ b/lib/plugins/output/output-sematext-events.js
@@ -1,0 +1,154 @@
+'use strict'
+const consoleLogger = require('../../util/logger.js')
+const request = require('requestretry')
+/** example configuration
+  output:
+    module: output-sematext-events
+    url: http://localhost:8080/events
+    format: ldjson
+    maxBufferSize: 1
+    flushInterval: 1
+    tags:
+      token: SPM_TOKEN
+      role: backend
+      host: myServerName
+    filter:
+      field: logSource
+      match: sensor.*
+*/
+class OutputSematextEvents {
+  constructor (config, eventEmitter) {
+    this.config = config
+    this.buffer = []
+    this.eventEmitter = eventEmitter
+    if (this.config.filter && this.config.filter.match && this.config.filter.field) {
+      this.config.filter.match = RegExp(this.config.filter.match)
+    }
+    if (this.config.ignoreFields && this.config.ignoreFields.length > 0) {
+      this.ignoreFields = {}
+      for (var i = 0; i < this.config.ignoreFields.length; i++) {
+        this.ignoreFields[this.config.ignoreFields[i]] = true
+      }
+    }
+    if (this.config.maxBufferSize === undefined) {
+      // set default
+      this.config.maxBufferSize = 1
+    }
+    if (this.config.maxBufferSize <= 0) {
+      // set default to 100, when buffer size is set to 0 or negative values
+      this.config.maxBufferSize = 100
+    }
+    if (!this.config.flushInterval) {
+      // set default 10 seconds
+      this.config.flushInterval = 10
+    }
+    if (this.config.flushInterval < 0.5) {
+      // don't allow more than 2 requests per second
+      this.config.flushInterval = 1
+    }
+  }
+
+  start () {
+    this.evtFunction = this.eventHandler.bind(this)
+    this.eventEmitter.on('data.parsed', this.evtFunction)
+    if (this.config.debug) {
+      consoleLogger.log('output-sematext-events plugin started ' + this.config.url)
+    }
+    var sendBuffer = this.sendBuffer.bind(this)
+    this.timerId = setInterval(function () {
+      sendBuffer()
+    }, 1000 * this.config.flushInterval)
+  }
+
+  stop (cb) {
+    this.eventEmitter.removeListener('data.parsed', this.evtFunction)
+    clearInterval(this.timerId)
+    cb()
+  }
+
+  addTobuffer (line) {
+    this.buffer.push(line + '\n')
+    if (this.buffer.length >= this.config.maxBufferSize) {
+      this.sendBuffer()
+    }
+  }
+
+  sendBuffer () {
+    var httpBody = ''
+    for (var i = 0; i < this.buffer.length; i++) {
+      httpBody = httpBody + this.buffer[i] + '\n'
+    }
+    if (httpBody.length > 0) {
+      this.buffer = []
+      this.send(httpBody)
+    }
+  }
+
+  send (body) {
+    if (this.config.debug) {
+      consoleLogger.log('output-sematext-events: ' + body.replace(/\n/g, '\n\t'))
+    }
+
+    var self = this
+    var options = {
+      method: 'post',
+      url: this.config.eventsReceiver,
+      body: body,
+      maxAttempts: 20,
+      retryDelay: 3000,
+      retryStrategy: request.RetryStrategies.HTTPOrNetworkError
+    }
+    request(options, function (err, response, body) {
+      if (self.config.debug === true && response && response.attempts) {
+        consoleLogger.log('output-sematext-events: ' + response.attempts + ' attempts ' + ' ' + options.url + ' ' + body + ' ' + response.statusCode)
+      }
+      if (err) {
+        self.eventEmitter.emit('error', err)
+      }
+    })
+  }
+
+  eventHandler (data, context) {
+    if (!context.index) {
+      if (this.config.debug === true) {
+        consoleLogger.log('output-sematext-events: no token')
+      }
+      return
+    }
+    if (!this.config.receiver) {
+      if (this.config.debug === true) {
+        consoleLogger.log('output-sematext-events: no events receiver URL')
+      }
+      return
+    }
+
+    // build the events receiver from the base receiver URL and the token
+    this.config.eventsReceiver = `${this.config.receiver}/${context.index}/event`
+
+    // enrich log with static tags
+    if (this.config.tags) {
+      data.tags = this.config.tags
+    }
+
+    // todo: alternative formats in http body
+    const msg = JSON.stringify(data)
+
+    if (this.config.filter !== undefined) {
+      // match field with filter expression
+      const fieldName = this.config.filter.field || 'logSource'
+      const matchValue = data[fieldName] || ''
+      const match = this.config.filter.match
+      if (match.test(matchValue)) {
+        return this.addTobuffer(msg)
+      } else {
+        if (this.config.debug === true) {
+          consoleLogger.log('output-sematext-events: filter expression' + match + ' did not match ' + matchValue)
+        }
+      }
+    } else {
+      return this.addTobuffer(msg)
+    }
+  }
+}
+
+module.exports = OutputSematextEvents

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "v8-profiler-next": "^1.2.1"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.3",
     "eslint": "^5.9.0",
     "mocha": "^7.0.1",
     "standard": "14.3.1"
@@ -149,5 +150,8 @@
       "beforeStage": "npx auto-changelog -p",
       "changelog": "npx auto-changelog --stdout --commit-limit false --unreleased --template ./changelog.hbs"
     }
+  },
+  "standard": {
+    "parser": "babel-eslint"
   }
 }


### PR DESCRIPTION
Added a new input plugin for Github Webhooks. The input plugin will run as a server and listen for HTTP requests. It will take token and region values from the URL and parse an event object from the GitHub Webhook. The output will send an HTTP request to the Sematext Events API.