### PR TITLE
Fix GEOIP_FIELDS config settings 

### DIFF
--- a/lib/plugins/output-filter/geoip.js
+++ b/lib/plugins/output-filter/geoip.js
@@ -6,7 +6,6 @@ var MaxMindReader = require('maxmind').Reader
 var cityLookup = null
 var geoIpStatus = {
   maxmindDbDir: process.env.MAXMIND_DB_DIR || '/tmp/',
-  fields: process.env.GEOIP_FIELDS,
   debug: !!process.env.DEBUG
 }
 
@@ -61,27 +60,32 @@ function geoipLookup (parsedObject, fieldName, outputFieldName) {
 function geoipOutputFilter (context, config, eventEmitter, data, callback) {
   // get config values from output-filter config
   if (!geoIpStatus.fields) {
-    geoIpStatus.fields = config.fields
+    if (process.env.GEOIP_FIELDS) {
+      geoIpStatus.fields =  process.env.GEOIP_FIELDS.replace(/\s/g, '').split(',')
+    }
+    geoIpStatus.fields = geoIpStatus.fields || config.fields || ['client_ip']
     geoIpStatus.debug = config.debug
+    consoleLogger.log('GeoIP: lookup enabled for fields ' + geoIpStatus.fields)
   }
   if (geoIpStatus.geoIpFailed === true) {
     return callback(null, data)
   }
-  var fields = config.fields || []
-  for (var i = 0; i < fields.length; i++) {
-    if ((data[fields[i]] !== undefined)) {
-      geoipLookup(data, fields[i], 'geoip')
+  for (var i = 0; i < geoIpStatus.fields.length; i++) {
+    if ((data[geoIpStatus.fields[i]] !== undefined)) {
+      geoipLookup(data, geoIpStatus.fields[i], 'geoip')
     }
   }
   return callback(null, data)
 }
 
+/*
 function test () {
   var cfg = { fields: ['client_ip'], maxmindDbDir: '/tmp/', debug: true }
   setInterval(() => {
-    geoipOutputFilter(null, cfg, null, { client_ip: '94.216.99.1' }, console.log)
+    geoipOutputFilter(null, cfg, null, { client_ip: '94.216.99.1'}, console.log)
   }, 200)
 }
+*/
 
 consoleLogger.log('GeoIP: Loading Maxmind DB ')
 initMaxmind()


### PR DESCRIPTION
Setting a list of fields to read the IP adress via GEOIP_FIELDS env variable did not work. 
This fix allows to set a list of fields e.g. GEOIP_FIELDS="ClientIP,remote_address,client_ip" 
