### PR TITLE
Journald streaming mode

### DIFF
--- a/lib/plugins/input/journald-upload.js
+++ b/lib/plugins/input/journald-upload.js
@@ -1,10 +1,10 @@
 const consoleLogger = require('../../util/logger.js')
 const http = require('http')
 const throng = require('throng')
+const split = require('split2')
+const createStreamThrottle = require('../../util/throttle')
 const extractTokenRegEx = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
 const tokenFormatRegEx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
-
-const __CURSOR = '__CURSOR'
 const _SYSTEMD_UNIT = '_systemd_unit'
 const SYSLOG_IDENTIFIER = 'syslog_identifier'
 const TokenBlacklist = require('../../util/token-blacklist.js')
@@ -14,7 +14,8 @@ function JournaldUpload (config, eventEmitter) {
   this.eventEmitter = eventEmitter
   this.removeFields = {}
   this.tokenBlackList = new TokenBlacklist(eventEmitter)
-
+  // limit per client throughput to 50 megabyte / s
+  this.throughputPerClient = this.config.maxInputRate || 5 * 1024 
   if (config.useSematextCommonSchema === undefined) {
     config.useSematextCommonSchema = true
   }
@@ -72,18 +73,18 @@ JournaldUpload.prototype.emitEvent = function (log, token) {
       return
     }
   }
-  this.addTags(log)
   let context = {
     sourceName: log[_SYSTEMD_UNIT] || log[SYSLOG_IDENTIFIER] || 'journald',
     name: 'journald'
   }
-
   if (token) {
     // set index, for elasticsearch output plugin
     context.index = token
   }
-
-  this.eventEmitter.emit('data.object', log, context)
+  if (Object.keys(log).length > 0) {
+    this.addTags(log)
+    this.eventEmitter.emit('data.object', log, context)
+  }
 }
 
 JournaldUpload.prototype.addTags = function (log) {
@@ -92,7 +93,7 @@ JournaldUpload.prototype.addTags = function (log) {
   }
   let keys = Object.keys(this.config.tags)
   for (let i = 0; i < keys.length; i++) {
-    // avoid setting _index when passed in URL
+    // avoid overwriting _index when passed in URL
     if (log[keys[i]] === undefined) {
       log[keys[i]] = this.config.tags[keys[i]]
     }
@@ -115,31 +116,32 @@ JournaldUpload.prototype.getHttpServer = function (aport, handler) {
   }
 }
 
+JournaldUpload.prototype.parseLine = function (log, line) {
+  if (!line) {
+    return log
+  }
+  let index = line.indexOf('=')
+  let fieldName = line.substr(0, index).toLowerCase()
+  if (!this.removeFields[fieldName]) {
+    log[fieldName] = line.substr(index + 1, line.length)
+  }
+  return log
+}
+
+
 JournaldUpload.prototype.parseBody = function (body, token) {
-  let self = this
   let lines = body.split('\n')
   let log = null
-  for (var i = 0; i < lines.length; i++) {
-    if (lines[i].indexOf(__CURSOR) > -1) {
-      log = {}
-    }
-    var index = lines[i].indexOf('=')
-    if (index > -1 && lines[i].length > 0) {
-      var fieldName = lines[i].substr(0, index)
-      var fieldValue = lines[i].substr(index + 1, lines[i].length)
-      if (!self.removeFields[fieldName]) {
-        log[fieldName.toLowerCase()] = fieldValue
-      }
-    } else {
-      if (lines[i] === '' && log !== null) {
-        self.emitEvent(log, token)
-        log = null
-      }
-    }
+  if (lines.length > 0) {
+    log = {}
+  } else {
+    return
   }
-  if (log !== null && log['@timestamp'] !== undefined) {
-    self.emitEvent(log, token)
+  // fastest loop is counting down 
+  for (let i = lines.length; i >= 0 ; --i) {
+    this.parseLine(log, lines[i])
   }
+  this.emitEvent(log, token)
 }
 
 JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
@@ -167,12 +169,16 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
       res.end(`invalid logs token in url ${req.url}`)
       return
     }
-
-    req.on('data', function (data) {
-      bodyIn += String(data)
-    })
-
-    req.on('end', function endHandler () {
+    
+    req.pipe(createStreamThrottle(this.throughputPerClient)).pipe(split()).on('data', function emitLine (data) {
+      // logs are spearated by empty lines
+      if (data.length == 0 && bodyIn.length > 0) {
+        self.parseBody(bodyIn, token)
+        bodyIn = ''
+        return
+      } 
+      bodyIn += `${data}\n`  
+    }).on('end', function endHandler () {
       self.parseBody(bodyIn, token)
       // send response to client
       res.writeHead(
@@ -180,7 +186,7 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
         { 'Content-Type': 'text/plain' }
       )
       res.end('OK\n')
-    })
+    }).on('error', console.error)   
   } catch (err) {
     res.statusCode = 500
     res.end()

--- a/lib/plugins/input/journald-upload.js
+++ b/lib/plugins/input/journald-upload.js
@@ -15,7 +15,7 @@ function JournaldUpload (config, eventEmitter) {
   this.removeFields = {}
   this.tokenBlackList = new TokenBlacklist(eventEmitter)
   // limit throughput per client  
-  this.throughputPerClient = this.config.maxInputRate || 50 * 1024 * 1024
+  this.throughputPerClient = this.config.maxInputRate || 10 * 1024 * 1024
   if (config.useSematextCommonSchema === undefined) {
     config.useSematextCommonSchema = true
   }
@@ -122,8 +122,12 @@ JournaldUpload.prototype.parseLine = function (log, line) {
   }
   let index = line.indexOf('=')
   let fieldName = line.substr(0, index).toLowerCase()
+  let value = line.substr(index + 1, line.length)
+  if (!isNaN(value)) {
+    value = Number(value)
+  }
   if (!this.removeFields[fieldName]) {
-    log[fieldName] = line.substr(index + 1, line.length)
+    log[fieldName] = value
   }
   return log
 }
@@ -171,6 +175,7 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
     }
     
     req.pipe(createStreamThrottle(this.throughputPerClient)).pipe(split()).on('data', function emitLine (data) {
+      // console.log(data, data.indexOf('\n'))
       // logs are spearated by empty lines
       if (data.length == 0 && bodyIn.length > 0) {
         self.parseBody(bodyIn, token)

--- a/lib/plugins/input/journald-upload.js
+++ b/lib/plugins/input/journald-upload.js
@@ -14,8 +14,8 @@ function JournaldUpload (config, eventEmitter) {
   this.eventEmitter = eventEmitter
   this.removeFields = {}
   this.tokenBlackList = new TokenBlacklist(eventEmitter)
-  // limit per client throughput to 50 megabyte / s
-  this.throughputPerClient = this.config.maxInputRate || 5 * 1024 
+  // limit throughput per client  
+  this.throughputPerClient = this.config.maxInputRate || 50 * 1024 * 1024
   if (config.useSematextCommonSchema === undefined) {
     config.useSematextCommonSchema = true
   }

--- a/lib/plugins/output-filter/journald-format.js
+++ b/lib/plugins/output-filter/journald-format.js
@@ -13,6 +13,7 @@ const PRIORITY = 'priority'
 const SYSLOG_FACILITY = 'syslog_facility'
 const CONTAINER_TAG = 'container_tag'
 const CONTAINER_ID_FULL = 'container_id_full'
+const CONTAINER_ID = 'container_id'
 const CONTAINER_NAME = 'container_name'
 
 // field mapping for Sematext Common Schema
@@ -86,9 +87,9 @@ function applySematextCommonSchema (context, config, eventEmitter, log, callback
       delete log[log[SYSLOG_FACILITY]]
     }
     // handling docker journald-drive fields
-    if (log[CONTAINER_ID_FULL]) {
+    if (log[CONTAINER_ID_FULL] || log[CONTAINER_NAME]) {
       log.container = {
-        id: log[CONTAINER_ID_FULL],
+        id: log[CONTAINER_ID_FULL] || log[CONTAINER_ID],
         name: log[CONTAINER_NAME],
         tag: log[CONTAINER_TAG]
       }

--- a/lib/plugins/output-filter/journald-format.js
+++ b/lib/plugins/output-filter/journald-format.js
@@ -35,6 +35,7 @@ const SEVERITY = [
   'info',
   'debug'
 ]
+
 const FACILITY = [
   'kern',
   'user',
@@ -78,13 +79,11 @@ function applySematextCommonSchema (context, config, eventEmitter, log, callback
       }
     }
     let prio = log[PRIORITY]
-    let facility = log[log[SYSLOG_FACILITY]]
+    let facility = log[SYSLOG_FACILITY]
     // handling syslog priorit and facility values 
     if (prio || facility) {
-      log.facility = FACILITY[facility] || String(facility)
-      log.severity = SEVERITY[prio] || String(prio)
-      delete log[PRIORITY]
-      delete log[log[SYSLOG_FACILITY]]
+      log.facility = FACILITY[facility]
+      log.severity = SEVERITY[prio]
     }
     // handling docker journald-drive fields
     if (log[CONTAINER_ID_FULL] || log[CONTAINER_NAME]) {


### PR DESCRIPTION
Systemd-journal-upload works in streaming mode, so we added: 
- streaming mode for HTTP requests
- changed parser  for journald export format to streaming mode

journald-format plugin: 
- improved detection of container logs by `container_name` and not only by `container_full_id`