### PR TITLE
Add token blacklists to HTTP receivers

### DIFF
--- a/lib/plugins/input/cloudfoundry.js
+++ b/lib/plugins/input/cloudfoundry.js
@@ -1,5 +1,8 @@
-var consoleLogger = require('../../util/logger.js')
-var http = require('http')
+const consoleLogger = require('../../util/logger.js')
+const http = require('http')
+const extractTokenRegEx = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+const tokenFormatRegEx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+const TokenBlacklist = require('../../util/token-blacklist.js')
 
 function jsonParse (text) {
   try {
@@ -24,7 +27,11 @@ function InputCloudFoundry (config, eventEmitter) {
   this.config = config
   this.eventEmitter = eventEmitter
   this.config.cfhttp = config.cfhttp || config.port
-  consoleLogger.log('value ' + this.config.cfhttp)
+  consoleLogger.log('cloudfoundry port: ' + this.config.cfhttp)
+  if (config.useIndexFromUrlPath === undefined) {
+    config.useIndexFromUrlPath = true
+  }
+  this.tokenBlackList = new TokenBlacklist(eventEmitter)
   if (config && config.blacklist) {
     this.config.blacklist = config.blacklist
   } else {
@@ -70,8 +77,8 @@ InputCloudFoundry.prototype.getHttpServer = function (aport, handler) {
 
 function filterCloudfoundryMessage (data, context) {
   if (data) {
-    data['_type'] = context.sourceName.replace('_' + context.index, '')
-    data['logSource'] = ('' + data['logSource']).replace('_' + context.index, '')
+    data._type = context.sourceName.replace('_' + context.index, '')
+    data.logSource = ('' + data.logSource).replace('_' + context.index, '')
     if (!data['@timestamp']) {
       data['@timestamp'] = new Date()
     }
@@ -89,8 +96,11 @@ InputCloudFoundry.prototype.cloudFoundryHandler = function (req, res) {
     var path = req.url.split('/')
     var token = null
     if (path.length > 1) {
-      if (path[1] && path[1].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[1])) {
-        token = path[1]
+      if (path[1] && path[1].length > 31 && tokenFormatRegEx.test(path[1])) {
+        const match = path[1].match(extractTokenRegEx)
+        if (match && match.length > 1) {
+          token = match[1]
+        }
       } else if (path[1] === 'health' || path[1] === 'ping') {
         res.statusCode = 200
         res.end('ok\n')
@@ -104,12 +114,10 @@ InputCloudFoundry.prototype.cloudFoundryHandler = function (req, res) {
       return
     }
 
-    if (self.config && self.config.blacklist && self.config.blacklist[token]) {
-      if (self.config.debug) {
-        consoleLogger.log('blacklisted request for' + token)
-      }
+    if ((self.config.useIndexFromUrlPath === true && !token) || self.tokenBlackList.isTokenInvalid(token)) {
       res.statusCode = 404
-      return res.end()
+      res.end(`invalid logs token in url ${req.url}\n`)
+      return
     }
     var body = ''
     req.on('data', function (data) {
@@ -121,7 +129,7 @@ InputCloudFoundry.prototype.cloudFoundryHandler = function (req, res) {
         if (!line) {
           return
         }
-        eventEmitter.emit('data.raw', line.trim(), {sourceName: 'cloudfoundry_' + token, index: token, filter: filterCloudfoundryMessage})
+        eventEmitter.emit('data.raw', line.trim(), { sourceName: 'cloudfoundry_' + token, index: token, filter: filterCloudfoundryMessage })
       })
       res.end('ok\n')
     })

--- a/lib/plugins/input/heroku.js
+++ b/lib/plugins/input/heroku.js
@@ -110,7 +110,7 @@ InputHeroku.prototype.herokuHandler = function (req, res) {
         return
       }
     }
-    
+
     if (!token) {
       res.end('<html><head><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"</head><body><div class="alert alert-danger" role="alert">Error: Missing Logsene Token ' +
         req.url + '. Please use /LOGSENE_TOKEN. More info: <ul><li><a href="https://github.com/sematext/logagent-js#logagent-as-heroku-log-drain">Heroku Log Drain for Logsene</a> </li><li><a href="https://www.sematext.com/logsene/">Logsene Log Management by Sematext</a></li></ul></div></body><html>')

--- a/lib/plugins/input/heroku.js
+++ b/lib/plugins/input/heroku.js
@@ -26,6 +26,9 @@ function extractJson (line, source) {
 function InputHeroku (config, eventEmitter) {
   this.config = config
   this.eventEmitter = eventEmitter
+  if (config.useIndexFromUrlPath === undefined) {
+    config.useIndexFromUrlPath = true
+  }
   this.tokenBlackList = new TokenBlacklist(eventEmitter)
   this.config.port = this.config.heroku || config.port
   if (config.workers) {

--- a/lib/plugins/input/heroku.js
+++ b/lib/plugins/input/heroku.js
@@ -1,5 +1,8 @@
-var consoleLogger = require('../../util/logger.js')
-var http = require('http')
+const consoleLogger = require('../../util/logger.js')
+const http = require('http')
+const extractTokenRegEx = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+const tokenFormatRegEx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+const TokenBlacklist = require('../../util/token-blacklist.js')
 
 function jsonParse (text) {
   try {
@@ -23,12 +26,8 @@ function extractJson (line, source) {
 function InputHeroku (config, eventEmitter) {
   this.config = config
   this.eventEmitter = eventEmitter
+  this.tokenBlackList = new TokenBlacklist(eventEmitter)
   this.config.port = this.config.heroku || config.port
-  if (config && config.blacklist) {
-    this.config.blacklist = config.blacklist
-  } else {
-    this.config.blacklist = {}
-  }
   if (config.workers) {
     this.config.herokuWorkers = config.workers
   } else {
@@ -53,7 +52,7 @@ InputHeroku.prototype.stop = function (cb) {
 
 InputHeroku.prototype.getHttpServer = function (aport, handler) {
   var _port = aport || process.env.PORT
-  if (aport === true) { // a commadn line flag was set but no port given
+  if (aport === true) { // a command line flag was set but no port given
     _port = process.env.PORT
   }
   var server = http.createServer(handler)
@@ -69,8 +68,8 @@ InputHeroku.prototype.getHttpServer = function (aport, handler) {
 
 function filterHerokuMessage (data, context) {
   if (data) {
-    data['_type'] = context.sourceName.replace('_' + context.index, '')
-    data['logSource'] = ('' + data['logSource']).replace('_' + context.index, '')
+    data._type = context.sourceName.replace('_' + context.index, '')
+    data.logSource = ('' + data.logSource).replace('_' + context.index, '')
     var msg = {
       message: data.message,
       app: data.app,
@@ -100,27 +99,30 @@ InputHeroku.prototype.herokuHandler = function (req, res) {
     var path = req.url.split('/')
     var token = null
     if (path.length > 1) {
-      if (path[1] && path[1].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[1])) {
-        token = path[1]
+      if (path[1] && path[1].length > 31 && tokenFormatRegEx.test(path[1])) {
+        const match = path[1].match(extractTokenRegEx)
+        if (match && match.length > 1) {
+          token = match[1]
+        }
       } else if (path[1] === 'health' || path[1] === 'ping') {
         res.statusCode = 200
         res.end('ok\n')
         return
       }
     }
+    
     if (!token) {
       res.end('<html><head><link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"</head><body><div class="alert alert-danger" role="alert">Error: Missing Logsene Token ' +
         req.url + '. Please use /LOGSENE_TOKEN. More info: <ul><li><a href="https://github.com/sematext/logagent-js#logagent-as-heroku-log-drain">Heroku Log Drain for Logsene</a> </li><li><a href="https://www.sematext.com/logsene/">Logsene Log Management by Sematext</a></li></ul></div></body><html>')
       return
     }
 
-    if (self.config && self.config.blacklist && self.config.blacklist[token]) {
-      if (self.config.debug) {
-        consoleLogger.log('blacklisted request for' + token)
-      }
+    if ((self.config.useIndexFromUrlPath === true && !token) || self.tokenBlackList.isTokenInvalid(token)) {
       res.statusCode = 404
-      return res.end()
+      res.end(`invalid logs token in url ${req.url}\n`)
+      return
     }
+
     var body = ''
     req.on('data', function (data) {
       body += data
@@ -131,7 +133,7 @@ InputHeroku.prototype.herokuHandler = function (req, res) {
         if (!line) {
           return
         }
-        self.eventEmitter.emit('data.raw', line, {sourceName: 'heroku_' + token, index: token, filter: filterHerokuMessage})
+        self.eventEmitter.emit('data.raw', line, { sourceName: 'heroku_' + token, index: token, filter: filterHerokuMessage })
       })
       res.end('ok\n')
     })

--- a/lib/plugins/input/kubernetesAudit.js
+++ b/lib/plugins/input/kubernetesAudit.js
@@ -1,10 +1,14 @@
-var consoleLogger = require('../../util/logger.js')
-var http = require('http')
-var throng = require('throng')
+const consoleLogger = require('../../util/logger.js')
+const http = require('http')
+const throng = require('throng')
+const extractTokenRegEx = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+const tokenFormatRegEx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+const TokenBlacklist = require('../../util/token-blacklist.js')
 
 function KubernetesAudit (config, eventEmitter) {
   this.config = config
   this.eventEmitter = eventEmitter
+  this.tokenBlackList = new TokenBlacklist(eventEmitter)
   if (config.worker) {
     this.config.worker = config.workers
   } else {
@@ -28,9 +32,8 @@ KubernetesAudit.prototype.stop = function (cb) {
 }
 
 KubernetesAudit.prototype.emitEvent = function (log, token) {
-  var config = this.config
   this.addTags(log)
-  var context = { name: 'k8sAudit', sourceName: 'k8sAudit' }
+  const context = { name: 'k8sAudit', sourceName: 'k8sAudit' }
   if (token) {
     context.index = token
   }
@@ -41,8 +44,8 @@ KubernetesAudit.prototype.addTags = function (log) {
   if (this.config.tags === undefined) {
     return
   }
-  var keys = Object.keys(this.config.tags)
-  for (var i = 0; i < keys.length; i++) {
+  const keys = Object.keys(this.config.tags)
+  for (let i = 0; i < keys.length; i++) {
     // avoid setting _index when passed in URL
     if (log[keys[i]] === undefined) {
       log[keys[i]] = this.config.tags[keys[i]]
@@ -51,13 +54,13 @@ KubernetesAudit.prototype.addTags = function (log) {
 }
 
 KubernetesAudit.prototype.getHttpServer = function (aport, handler) {
-  var _port = aport || process.env.PORT || 9200
+  let _port = aport || process.env.PORT || 9200
   if (aport === true) {
     _port = process.env.PORT
   }
-  var server = http.createServer(handler)
+  let server = http.createServer(handler)
   try {
-    var bindAddress = this.config.bindAddress || '0.0.0.0'
+    const bindAddress = this.config.bindAddress || '0.0.0.0'
     server = server.listen(_port, bindAddress)
     consoleLogger.log('Logagent listening (http k8s audit): ' + bindAddress + ':' + _port + ', process id: ' + process.pid)
     return server
@@ -67,31 +70,45 @@ KubernetesAudit.prototype.getHttpServer = function (aport, handler) {
 }
 
 KubernetesAudit.prototype.parseBody = function (body, token) {
-  var self = this
-  var docs = JSON.parse(body)
+  if (body.length === 0) {
+    return
+  }
+  const self = this
+  const docs = JSON.parse(body)
   if (docs.items && docs.items.length > 0) {
-    for (var i = 0; i < docs.items.length; i++) {
-      var log = docs.items[i]
+    for (let i = 0; i < docs.items.length; i++) {
+      const log = docs.items[i]
       log['@timestamp'] = new Date(log.timestamp)
       self.emitEvent(log, token)
     }
+  } else {
+    // unknow structure, let's index the doc to ease trouble shooting
+    self.emitEvent(docs, token)
   }
 }
 
 KubernetesAudit.prototype.HttpHandler = function (req, res) {
   try {
-    var self = this
-    var bodyIn = ''
-    var path = req.url.split('/')
-    var token = null
+    const self = this
+    const path = req.url.split('/')
+    let token = null
+    let bodyIn = ''
     if (self.config.useIndexFromUrlPath === true && path.length > 1) {
-      if (path[1] && path[1].length > 31 && /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[1])) {
-        token = path[1]
+      if (path[1] && path[1].length > 31 && tokenFormatRegEx.test(path[1])) {
+        const match = path[1].match(extractTokenRegEx)
+        if (match && match.length > 1) {
+          token = match[1]
+        }
       } else if (path[1] === 'health' || path[1] === 'ping') {
         res.statusCode = 200
         res.end('ok\n')
         return
       }
+    }
+    if ((self.config.useIndexFromUrlPath === true && !token) || self.tokenBlackList.isTokenInvalid(token)) {
+      res.statusCode = 401
+      res.end(`invalid logs token in url ${req.url}`)
+      return
     }
     req.on('data', function (data) {
       bodyIn += String(data)
@@ -99,12 +116,15 @@ KubernetesAudit.prototype.HttpHandler = function (req, res) {
     })
 
     req.on('end', function endHandler () {
-      self.parseBody(bodyIn, token) 
+      try {
+        self.parseBody(bodyIn, token)
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' })
+        res.end(`Invalid json input: ${err}\n`)
+        return
+      }
       // send response to client
-      res.writeHead(
-        200,
-        { 'Content-Type': 'text/plain' }
-      )
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
       res.end('OK\n')
     })
   } catch (err) {
@@ -116,8 +136,8 @@ KubernetesAudit.prototype.HttpHandler = function (req, res) {
 
 KubernetesAudit.prototype.startKubernetesAudit = function (id) {
   this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
-  var exitInProgress = false
-  var terminate = function (reason) {
+  let exitInProgress = false
+  const terminate = function terminate (reason) {
     return function () {
       if (exitInProgress) {
         return
@@ -133,5 +153,3 @@ KubernetesAudit.prototype.startKubernetesAudit = function (id) {
 }
 
 module.exports = KubernetesAudit
-
-


### PR DESCRIPTION
Following input plugins use automatic token blacklist: 
- Kubernetes Audit 
- Heroku 
- Cloudfoundry 