### PR TITLE
Issue #206

### DIFF
--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -105,6 +105,11 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
   }
   var config = reduceConfig(context, data, this.config)
   var index = data._index || context.index || config.index || process.env.LOGSENE_TOKEN
+
+  console.log('\n\n\n\n\n')
+  console.log(`${index}`)
+  console.log('\n\n\n\n\n')
+
   if (config.tokenMapper) {
     if (config.dropLogsForUnmatchedIndices === true) {
       index = config.tokenMapper.findToken(data.logSource || context.sourceName)

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -82,7 +82,7 @@ OutputElasticsearch.prototype.getLogger = function (token, type, config, logsRec
     }.bind(this))
     logger.on('error', function (err) {
       this.laStats.httpFailed++
-      let errorMessage = 'Error in Elasticsearch request: ' + formatObject(err) + ' / ' + formatObject(err.err)
+      const errorMessage = 'Error in Elasticsearch request: ' + formatObject(err) + ' / ' + formatObject(err.err)
       // consoleLogger.error(errorMessage)
       this.eventEmitter.emit('error', errorMessage)
     }.bind(this))
@@ -104,11 +104,11 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
     return
   }
   var config = reduceConfig(context, data, this.config)
-  var index = data._index || context.index || config.index || process.env.LOGSENE_TOKEN
+  var index = data._index || context.index || config.index || process.env.LOGSENE_TOKEN || process.env.LOGS_TOKEN
 
-  console.log('\n\n\n\n\n')
-  console.log(`${index}`)
-  console.log('\n\n\n\n\n')
+  consoleLogger.log('\n\n\n\n\n')
+  consoleLogger.log(`index: ${index}`)
+  consoleLogger.log('\n\n\n\n\n')
 
   if (config.tokenMapper) {
     if (config.dropLogsForUnmatchedIndices === true) {
@@ -120,13 +120,13 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
   if (index) {
     // support for time-based index patterns
     index = applyDateFormatToIndex(index, data)
-    this.indexData(index, data['_type'] || 'logs', data, config, context.logsReceiverUrl)
+    this.indexData(index, data._type || 'logs', data, config, context.logsReceiverUrl)
   }
   if (context.logsReceiver && context.logsReceiver.length > 0) {
     for (let i = 0; i < context.logsReceiver.length; i++) {
       this.indexData(
         applyDateFormatToIndex(context.logsReceiver[i].index, data),
-        data['_type'] || 'logs', data, config, context.logsReceiver[i].url)
+        data._type || 'logs', data, config, context.logsReceiver[i].url)
     }
   }
 }

--- a/lib/util/logger.js
+++ b/lib/util/logger.js
@@ -28,7 +28,7 @@ var WARN = 1
 
 var ERROR = 0
 var chalk = require('chalk')
-var version = require('../../package.json').version                            
+var version = require('../../package.json').version
 
 function logWithNodeModuleInfo (level, text) {
   var e = new Error('Oops!')


### PR DESCRIPTION
There was a bug in the Elasticsearch output plugin. When setting the `LOGS_TOKEN` in a Docker configuration, while **not** setting the token in the `output` section of the Logagent conf file, the Elasticsearch output plugin would not read the token at all if the logs were being parsed from a file on the host machine.

This adds a fix for setting `LOGS_TOKEN` in a Docker env and reading file input from files on the host machine.