### PR TITLE
SC-7164: Added token blacklisting for Github Webhook input

### DIFF
--- a/lib/plugins/input/webhooks/github.js
+++ b/lib/plugins/input/webhooks/github.js
@@ -1,6 +1,7 @@
 const http = require('http')
 const throng = require('throng')
 const consoleLogger = require('../../../util/logger.js')
+const TokenBlacklist = require('../../../util/token-blacklist')
 const {
   parseUrlPath,
   initEvent,
@@ -12,6 +13,8 @@ class GitHub {
   constructor (config, eventEmitter) {
     this.config = config
     this.eventEmitter = eventEmitter
+    this.tokenBlackList = new TokenBlacklist(eventEmitter)
+
     if (config.worker) {
       this.config.worker = config.workers
     } else {
@@ -70,7 +73,7 @@ class GitHub {
 
   httpHandler (req, res) {
     try {
-      const self = this
+      const emitEvent = this.emitEvent.bind(this)
       let bodyIn = ''
 
       const {
@@ -78,8 +81,10 @@ class GitHub {
         err
       } = parseUrlPath({
         useIndexFromUrlPath: this.config.useIndexFromUrlPath,
-        path: req.url.split('/'),
-        webhookName: 'github'
+        url: req.url,
+        webhookName: 'github',
+        tokenBlackList: this.tokenBlackList,
+        invalidTokenStatus: this.config.invalidTokenStatus
       })
 
       if (err) {
@@ -93,9 +98,7 @@ class GitHub {
       })
       req.on('end', () => {
         const log = parseReq({ headers: req.headers, bodyIn })
-        if (log) {
-          self.emitEvent(log, token)
-        }
+        if (log) { emitEvent(log, token) }
 
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.end('OK\n')

--- a/lib/plugins/input/webhooks/util.js
+++ b/lib/plugins/input/webhooks/util.js
@@ -1,5 +1,7 @@
-const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
+const parseUrlPath = ({ useIndexFromUrlPath, url, webhookName, tokenBlackList, invalidTokenStatus }) => {
   // Has to return an object
+
+  const path = url.split('/')
 
   if (useIndexFromUrlPath !== true) {
     return {}
@@ -26,6 +28,15 @@ const parseUrlPath = ({ useIndexFromUrlPath, path, webhookName }) => {
     /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(path[2])
   ) {
     urlPath.token = path[2]
+  }
+
+  if ((useIndexFromUrlPath === true && !urlPath.token) || tokenBlackList.isTokenInvalid(urlPath.token)) {
+    return {
+      err: {
+        statusCode: invalidTokenStatus || 403,
+        message: `Invalid LOGS_TOKEN in URL ${url}\n`
+      }
+    }
   }
 
   return urlPath

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -72,7 +72,6 @@ OutputElasticsearch.prototype.getLogger = function (token, type, config, logsRec
     if (this.httpOptions && url !== logsReceiverUrl) {
       options.httpOptions = this.httpOptions
     }
-    // console.log('using type ' + usedType)
     var logger = new Logsene(token, usedType, url,
       config.diskBufferDir, options)
     this.laStats.usedTokens.push(token)
@@ -83,7 +82,6 @@ OutputElasticsearch.prototype.getLogger = function (token, type, config, logsRec
     logger.on('error', function (err) {
       this.laStats.httpFailed++
       const errorMessage = 'Error in Elasticsearch request: ' + formatObject(err) + ' / ' + formatObject(err.err)
-      // consoleLogger.error(errorMessage)
       this.eventEmitter.emit('error', errorMessage)
     }.bind(this))
     logger.on('rt', function (data) {

--- a/lib/plugins/output/output-sematext-events.js
+++ b/lib/plugins/output/output-sematext-events.js
@@ -16,6 +16,15 @@ const request = require('requestretry')
       field: logSource
       match: sensor.*
 */
+
+function jsonParse (text) {
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    return null
+  }
+}
+
 class OutputSematextEvents {
   constructor (config, eventEmitter) {
     this.config = config
@@ -99,11 +108,14 @@ class OutputSematextEvents {
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError
     }
     request(options, function (err, response, body) {
-      if (self.config.debug === true && response && response.attempts) {
-        consoleLogger.log('output-sematext-events: ' + response.attempts + ' attempts ' + ' ' + options.url + ' ' + body + ' ' + response.statusCode)
+      if (response.statusCode === 403) {
+        self.eventEmitter.emit('error', jsonParse(body).error)
       }
       if (err) {
         self.eventEmitter.emit('error', err)
+      }
+      if (self.config.debug === true && response && response.attempts) {
+        consoleLogger.log('output-sematext-events: ' + response.attempts + ' attempts ' + ' ' + options.url + ' ' + body + ' ' + response.statusCode)
       }
     })
   }

--- a/lib/util/token-blacklist.js
+++ b/lib/util/token-blacklist.js
@@ -2,29 +2,35 @@ const LRU = require('lru-cache')
 const consoleLogger = require('./logger.js')
 
 class TokenBlacklist {
-  constructor(eventEmitter, maxIndexingErrors, errorRegex) {
+  constructor (eventEmitter, maxIndexingErrors, errorRegex) {
     this.errorRegex = errorRegex || /Application not found for token (\S+),/
-    this.maxIndexingErrors = maxIndexingErrors || 1 // failures before blacklisting tokens 
+    this.maxIndexingErrors = maxIndexingErrors || 1 // failures before blacklisting tokens
     this.invalidTokens = new LRU({
       max: 5000,
       maxAge: 10 * 60 * 1000
     })
+
     eventEmitter.on('error', function (err) {
-      // blacklist tokens ony when the token is unknown 
-      let match = String(err).match(this.errorRegex)
-      if (match && match.length > 1) {
-        if (!this.invalidTokens.get(match[1])) {
-          this.invalidTokens.set(match[1], 1)
-        } else {
-          this.invalidTokens.set(match[1], this.invalidTokens.get(match[1]))
-        }
-        if (this.invalidTokens.get(match[1]) >= this.maxIndexingErrors) {
-          consoleLogger.log(`Invalid token added to blacklist ${match[1]}`)
-        }
+      // blacklist tokens only when the token is unknown
+      const match = String(err).match(this.errorRegex)
+      const token = match && match.length > 1 && match[1]
+      if (!token) {
+        return
+      }
+
+      if (!this.invalidTokens.get(token)) {
+        this.invalidTokens.set(token, 1)
+      } else {
+        this.invalidTokens.set(token, this.invalidTokens.get(token))
+      }
+
+      if (this.invalidTokens.get(token) >= this.maxIndexingErrors) {
+        consoleLogger.log(`Invalid token added to blacklist ${token}`)
       }
     }.bind(this))
   }
-  isTokenInvalid(token) {
+
+  isTokenInvalid (token) {
     return this.invalidTokens.get(token) >= this.maxIndexingErrors
   }
 }


### PR DESCRIPTION
This PR will add:

- [x] Checking if a token is on the blacklist in the GitHub Webhook input plugin
- [x] Adding tokens to the blacklist in the Sematext Events output plugin if the token is rejected from the Logs receiver with a 403 status.