### PR TITLE
Gelf debug option

### DIFF
--- a/config/example.yml
+++ b/config/example.yml
@@ -817,6 +817,8 @@ output:
   #  host: localhost
   #  # graylog port (default: 12201)
   #  port: 12201
+  #  # Dump all events
+  #  debug: false
   #  # compression 'gzip' or 'deflate' (default: 'deflate')
   #  compressType: deflate
   #  # size of chunked messages in bytes (default: 1240)

--- a/config/examples/stdin-gelf-output.yml
+++ b/config/examples/stdin-gelf-output.yml
@@ -11,6 +11,8 @@ output:
     host: localhost
     # graylog port (default: 12201)
     port: 12201
+    # Dump all events
+    debug: false  
     # compression 'gzip' or 'deflate' (default: 'deflate')
     compressType: deflate
     # size of chunked messages in bytes (default: 1240)

--- a/lib/plugins/output/gelfout.js
+++ b/lib/plugins/output/gelfout.js
@@ -11,7 +11,9 @@ function OutputGELF (config, eventEmitter) {
 }
 
 OutputGELF.prototype.eventHandler = function (data, context) {
-  console.log('context ' + JSON.stringify(context))
+  if (this.config.debug) {
+    console.log('context ' + JSON.stringify(context))
+  }
   var log = graygelf({host: this.config.host, port: this.config.port, compressType: this.compression, chunkSize: this.chunkSize})
   var rawMessage = this.mapData(data, context)
   log.raw(rawMessage)


### PR DESCRIPTION
I noticed that the GELF output plugin fills the screen with a flood of messages.  I found it very helpful to have a debug option for that and only do those if debug=true.  I was thinking others could benefit from this and wanted to submit this PR.  Let me know if there are any concerns or questions.  Thanks.