### PR TITLE
Refactor commits field

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -258,7 +258,7 @@ LaCli.prototype.loadPlugins = function (configFile) {
     { module: '../lib/plugins/input/stdin', config: stdInConfig, globalConfig: configFile },
     { module: '../lib/plugins/output/stdout', config: stdOutConfig, globalConfig: configFile }
   ]
-  
+
   if (this.argv.k8sEvents) {
     plugins.push({
       module: 'input-kubernetes-events',

--- a/lib/plugins/output-filter/github-logs-format.js
+++ b/lib/plugins/output-filter/github-logs-format.js
@@ -1,6 +1,11 @@
 function formatSematextLogsOutput (context, config, eventEmitter, log, callback) {
   try {
     const parsedLog = parseGithubEvent(log)
+
+    if (config.debug) {
+      console.log(parsedLog)
+    }
+
     if (parsedLog) { callback(null, parsedLog) }
   } catch (e) {
     callback(e, log)
@@ -314,14 +319,9 @@ const parsePush = (event, body) => {
       modified
     }
 
-    acc[id] = currCommit
+    acc.push(currCommit)
     return acc
-  }, {})
-
-  const parsedCommits = {
-    count: commitCount,
-    ...reducedCommits
-  }
+  }, [])
 
   return {
     ...initEvent({ event, action, webhookName: 'GitHub' }),
@@ -332,7 +332,8 @@ const parsePush = (event, body) => {
     repository: parsedRepo,
     sender: parsedSender,
     headCommit: parsedHeadCommit,
-    commits: parsedCommits
+    commitCount,
+    commits: reducedCommits
   }
 }
 


### PR DESCRIPTION
The commits field should be an array to avoid `Too many fields in index` issue.