### PR TITLE
Removed container.host.hostname from docker and k8s enrichment

### DIFF
--- a/lib/plugins/input-filter/kubernetesContainerd.js
+++ b/lib/plugins/input-filter/kubernetesContainerd.js
@@ -15,14 +15,7 @@ function parseK8sFileName (sourceName) {
 
   if (meta.length === 3) {
     info.kubernetes = {
-      pod: {
-        name: meta[0],
-        container: {
-          host: {
-            hostname: process.env.SPM_REPORTED_HOSTNAME || process.env.HOSTNAME
-          }
-        }
-      },
+      pod: { name: meta[0] },
       namespace: meta[1]
     }
     index = meta[2].lastIndexOf('-')

--- a/lib/plugins/output-filter/docker-log-enrichment.js
+++ b/lib/plugins/output-filter/docker-log-enrichment.js
@@ -55,10 +55,7 @@ module.exports = function enrichDockerLogs (context, config, eventEmitter, data,
     id: context.container_long_id,
     type: 'docker',
     name: context.container_name,
-    image: parser.parseImage(context.image || ''),
-    host: {
-      hostname: process.env.SPM_REPORTED_HOSTNAME
-    }
+    image: parser.parseImage(context.image || '')
   }
   data.os = {
     host: process.env.SPM_REPORTED_HOSTNAME


### PR DESCRIPTION
This PR solves the issue of field duplication. 
We have a default `os.host` field and do not need the `container.host.hostname` field at all.