### PR TITLE
Fix #224 - Enable advanced log routing when running Logagent with Docker

### DIFF
--- a/lib/plugins/input/docker/docker.js
+++ b/lib/plugins/input/docker/docker.js
@@ -142,7 +142,7 @@ InputDockerSocket.prototype.logLine = function (messageText, data, next) {
     time: data.time,
     enrichEvent: {
       // make sure each docker log gets timestamp from docker engine
-      '@timstamp': new Date(data.time)
+      '@timestamp': new Date(data.time)
     }
   }
   var dockerInspect = dockerInspectCache[data.id]

--- a/lib/plugins/input/docker/docker.js
+++ b/lib/plugins/input/docker/docker.js
@@ -142,7 +142,7 @@ InputDockerSocket.prototype.logLine = function (messageText, data, next) {
     time: data.time,
     enrichEvent: {
       // make sure each docker log gets timestamp from docker engine
-      '@timestamp': new Date(data.time)
+      '@timestamp_docker_engine': new Date(data.time)
     }
   }
   var dockerInspect = dockerInspectCache[data.id]

--- a/lib/plugins/input/docker/dockerInspect.js
+++ b/lib/plugins/input/docker/dockerInspect.js
@@ -193,10 +193,6 @@ function getLogseneEnabled (info) {
     info.LOGS_DESTINATION = getEnvVar('LOGS_DESTINATION', info.Config.Env)
   }
 
-  console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-  console.log(info)
-  console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
-
   return info
 }
 

--- a/lib/plugins/input/docker/dockerInspect.js
+++ b/lib/plugins/input/docker/dockerInspect.js
@@ -169,21 +169,34 @@ function getLogseneEnabled (info) {
   info.LOGSENE_TOKEN = token || process.env.LOGS_TOKEN || process.env.LOGSENE_TOKEN
 
   // get optional log receiver URLs
-  let logsReceiver = null
-  if (info.Config && info.Config.Labels && info.Config.Labels.LOGS_RECEIVER_URL) {
-    logsReceiver = info.Config.Labels.LOGS_RECEIVER_URL
+  let logsReceivers = null
+  if (info.Config && info.Config.Labels && info.Config.Labels.LOGS_RECEIVER_URLS) {
+    logsReceivers = info.Config.Labels.LOGS_RECEIVER_URLS
   } else {
-    logsReceiver = getEnvVar('LOGS_RECEIVER_URL', info.Config.Env)
+    logsReceivers = getEnvVar('LOGS_RECEIVER_URLS', info.Config.Env)
   }
-  if (logsReceiver) {
-    info.logsReceiver = parser.parseReceiverList(logsReceiver)
+  if (logsReceivers) {
+    info.LOGS_RECEIVER_URLS = parser.parseReceiverList(logsReceivers)
   }
+
+  // get optional log receiver
+  if (info.Config && info.Config.Labels && info.Config.Labels.LOGS_RECEIVER_URL) {
+    info.LOGS_RECEIVER_URL = info.Config.Labels.LOGS_RECEIVER_URL
+  } else {
+    info.LOGS_RECEIVER_URL = getEnvVar('LOGS_RECEIVER_URL', info.Config.Env)
+  }
+
   // get optional logs target name
   if (info.Config && info.Config.Labels && info.Config.Labels.LOGS_DESTINATION) {
     info.LOGS_DESTINATION = info.Config.Labels.LOGS_DESTINATION
   } else {
     info.LOGS_DESTINATION = getEnvVar('LOGS_DESTINATION', info.Config.Env)
   }
+
+  console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
+  console.log(info)
+  console.log('\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n')
+
   return info
 }
 

--- a/lib/plugins/output-filter/docker-log-enrichment.js
+++ b/lib/plugins/output-filter/docker-log-enrichment.js
@@ -93,14 +93,19 @@ module.exports = function enrichDockerLogs (context, config, eventEmitter, data,
       data.swarm = swarmInfo
     }
   }
-  // set logs receiver url for output plugins
-  if (context.dockerInspect && context.dockerInspect.logsReceiver) {
-    context.logsReceiver = context.dockerInspect.logsReceiver
+  // set logs receiver urls for output plugins when you have multiple URLS
+  if (context.dockerInspect && context.dockerInspect.logsReceivers) {
+    context.logsReceivers = context.dockerInspect.LOGS_RECEIVER_URLS
+  }
+  // set logs receiver urls for output plugins when you have one URL
+  if (context.dockerInspect && context.dockerInspect.LOGS_RECEIVER_URL) {
+    context.logsReceiver = context.dockerInspect.LOGS_RECEIVER_URL
   }
   // set logs destination / name of ES output module
   if (context.dockerInspect && context.dockerInspect.LOGS_DESTINATION) {
     context.logsDestination = context.dockerInspect.LOGS_DESTINATION
   }
+
   var logObject = data
   // make sure that top level message field is a String
   var messageString = logObject.message || logObject.msg || logObject.MESSAGE

--- a/lib/plugins/output-filter/docker-log-enrichment.js
+++ b/lib/plugins/output-filter/docker-log-enrichment.js
@@ -94,7 +94,7 @@ module.exports = function enrichDockerLogs (context, config, eventEmitter, data,
     }
   }
   // set logs receiver urls for output plugins when you have multiple URLS
-  if (context.dockerInspect && context.dockerInspect.logsReceivers) {
+  if (context.dockerInspect && context.dockerInspect.LOGS_RECEIVER_URLS) {
     context.logsReceivers = context.dockerInspect.LOGS_RECEIVER_URLS
   }
   // set logs receiver urls for output plugins when you have one URL

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -119,8 +119,11 @@ function checkLogsEnabled (pod, data, context, config) {
 function checkLogsReceiverUrl (pod, data, context) {
   var annotations = pod.metadata.annotations
   if (annotations && annotations['sematext.com/logs-receiver-url']) {
-    context.logsReceiver = parser.parseReceiverList(annotations['sematext.com/logs-receiver-url'])
+    context.logsReceivers = parser.parseReceiverList(annotations['sematext.com/logs-receiver-urls'])
+    return
   }
+
+  context.logsReceiver = annotations['sematext.com/logs-receiver-url']
 }
 
 function addLogsIndex (pod, data) {

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -123,7 +123,7 @@ function checkLogsReceiverUrl (pod, data, context) {
     return
   }
 
-  context.logsReceiver = annotations['sematext.com/logs-receiver-url']
+  context.logsReceiver = annotations && annotations['sematext.com/logs-receiver-url']
 }
 
 function addLogsIndex (pod, data) {

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -118,7 +118,7 @@ function checkLogsEnabled (pod, data, context, config) {
 
 function checkLogsReceiverUrl (pod, data, context) {
   var annotations = pod.metadata.annotations
-  if (annotations && annotations['sematext.com/logs-receiver-url']) {
+  if (annotations && annotations['sematext.com/logs-receiver-urls']) {
     context.logsReceivers = parser.parseReceiverList(annotations['sematext.com/logs-receiver-urls'])
     return
   }

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -106,8 +106,9 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
   if (context.logsDestination && this.config.configName && this.config.configName.indexOf(context.logsDestination) === -1) {
     return
   }
-  var config = reduceConfig(context, data, this.config)
-  var index = data._index || context.index || config.index || process.env.LOGSENE_TOKEN || process.env.LOGS_TOKEN
+  const config = reduceConfig(context, data, this.config)
+  let index = data._index || context.index || config.index || process.env.LOGSENE_TOKEN || process.env.LOGS_TOKEN
+  const logsReceiverUrl = context.logsReceiver || process.env.LOGS_RECEIVER_URL
 
   if (config.tokenMapper) {
     if (config.dropLogsForUnmatchedIndices === true) {
@@ -116,16 +117,17 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
       index = config.tokenMapper.findToken(data.logSource || context.sourceName) || index
     }
   }
+
   if (index) {
-    // support for time-based index patterns
     index = applyDateFormatToIndex(index, data)
-    this.indexData(index, data._type || 'logs', data, config, context.logsReceiverUrl)
+    this.indexData(index, data._type || 'logs', data, config, logsReceiverUrl)
   }
-  if (context.logsReceiver && context.logsReceiver.length > 0) {
-    for (let i = 0; i < context.logsReceiver.length; i++) {
+
+  if (context.logsReceivers && context.logsReceivers.length > 0) {
+    for (let i = 0; i < context.logsReceivers.length; i++) {
       this.indexData(
-        applyDateFormatToIndex(context.logsReceiver[i].index, data),
-        data._type || 'logs', data, config, context.logsReceiver[i].url)
+        applyDateFormatToIndex(context.logsReceivers[i].index, data),
+        data._type || 'logs', data, config, context.logsReceivers[i].url)
     }
   }
 }

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -124,11 +124,10 @@ OutputElasticsearch.prototype.eventHandler = function (data, context) {
   }
 
   if (context.logsReceivers && context.logsReceivers.length > 0) {
-    for (let i = 0; i < context.logsReceivers.length; i++) {
-      this.indexData(
-        applyDateFormatToIndex(context.logsReceivers[i].index, data),
-        data._type || 'logs', data, config, context.logsReceivers[i].url)
-    }
+    context.logsReceivers.forEach(receiver => {
+      const receiverIndex = applyDateFormatToIndex(receiver.index, data)
+      this.indexData(receiverIndex, data._type || 'logs', data, config, receiver.url)
+    })
   }
 }
 

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -58,11 +58,7 @@ OutputElasticsearch.prototype.indexData = function (token, logType, data, config
 
   if (config.debug) {
     consoleLogger.log('DEBUG-ES-OUTPUT')
-    consoleLogger.log('Shipped Log: ', {
-      severity: data.severity || data.level || 'info',
-      message: data.message || data.msg || data.MESSAGE,
-      data
-    })
+    consoleLogger.log(`Shipped Log: { severity: ${data.severity || data.level || 'info'}, message: ${data.message || data.msg || data.MESSAGE}, data: ${data} }`)
     consoleLogger.log(`Endpoint: ${logsReceiverUrl}/${token}`)
   }
 }

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -57,9 +57,12 @@ OutputElasticsearch.prototype.indexData = function (token, logType, data, config
   logger.log(data.severity || data.level || 'info', data.message || data.msg || data.MESSAGE, data)
 
   if (config.debug) {
-    consoleLogger.log('DEBUG-ES-OUTPUT')
-    consoleLogger.log(`Shipped Log: { severity: ${data.severity || data.level || 'info'}, message: ${data.message || data.msg || data.MESSAGE}, data: ${data} }`)
-    consoleLogger.log(`Endpoint: ${logsReceiverUrl}/${token}`)
+    consoleLogger.log(
+      'DEBUG-ES-OUTPUT\n' +
+      `Shipped Log: { severity: ${data.severity || data.level || 'info'}, message: ${data.message || data.msg || data.MESSAGE} }\n` +
+      `Endpoint: ${logsReceiverUrl}/${token}\n` +
+      'Shipped Log Data: ', ...data
+    )
   }
 }
 

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -58,7 +58,12 @@ OutputElasticsearch.prototype.indexData = function (token, logType, data, config
 
   if (config.debug) {
     consoleLogger.log('DEBUG-ES-OUTPUT')
-    consoleLogger.log(data.severity || data.level || 'info', data.message || data.msg || data.MESSAGE, data)
+    consoleLogger.log('Shipped Log: ', {
+      severity: data.severity || data.level || 'info',
+      message: data.message || data.msg || data.MESSAGE,
+      data
+    })
+    consoleLogger.log(`Endpoint: ${logsReceiverUrl}/${token}`)
   }
 }
 

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -61,7 +61,7 @@ OutputElasticsearch.prototype.indexData = function (token, logType, data, config
       'DEBUG-ES-OUTPUT\n' +
       `Shipped Log: { severity: ${data.severity || data.level || 'info'}, message: ${data.message || data.msg || data.MESSAGE} }\n` +
       `Endpoint: ${logsReceiverUrl}/${token}\n` +
-      'Shipped Log Data: ', ...data
+      'Shipped Log Data: ', data
     )
   }
 }

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -60,8 +60,7 @@ OutputElasticsearch.prototype.indexData = function (token, logType, data, config
     consoleLogger.log(
       'DEBUG-ES-OUTPUT\n' +
       `Shipped Log: { severity: ${data.severity || data.level || 'info'}, message: ${data.message || data.msg || data.MESSAGE} }\n` +
-      `Endpoint: ${logsReceiverUrl}/${token}\n` +
-      'Shipped Log Data: ', data
+      `Endpoint: ${logsReceiverUrl}/${token}`
     )
   }
 }

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -9,18 +9,23 @@ function parseReceiverList (receiverListAsString) {
   if (!receiverListAsString) {
     return undefined
   }
-  let receivers = []
-  let parseUrlRegx = /(\S+:\/\/\S+?)\/(\S+)$/i
-  let receiverList = receiverListAsString.split(',')
-  for (let receiver of receiverList) {
-    let url = receiver.match(parseUrlRegx)
-    if (url && url.length === 3) {
-      receivers.push({
-        url: url[1],
-        index: url[2]
-      })
-    }
-  }
+
+  const parseUrlRegexMultiReceivers = /(\S+:\/\/\S+?)\/(\S+)$/i
+  const receiverList = receiverListAsString.split(',')
+
+  const receivers = receiverList
+    .map(receiver => {
+      const match = receiver.match(parseUrlRegexMultiReceivers)
+      if (!(match && match.length === 3)) {
+        return
+      }
+
+      return {
+        url: match[1],
+        index: match[2]
+      }
+    })
+
   return receivers
 }
 


### PR DESCRIPTION
This PR fixes #224 and enables fine-grained log routing with Docker.

I've added another env var option. `LOGS_RECEIVER_URLS` will enable adding multiple receiver URLs in a comma separated list. These URLs need to contain the token/index of the Elasticsearch endpoint as well.

The existing `LOGS_RECEIVER_URL` env var is now limited to one endpoint and requires adding the `LOGS_TOKEN` as a separate env var. 

It is now possible to add `LOGS_TOKEN` and `LOGS_RECEIVER_URL` to the env vars of containers you want to ship logs for. Setting them on a container-basis will overwrite default settings. Using it with `LA_CONFIG_OVERRIDE=true` with `LOGS_ENABLED_DEFAULT=false` in the Logagent container env vars will let you disable log shipping for all containers except for container where you set `LOGS_ENABLED=true`, `LOGS_TOKEN`, and `LOGS_RECEIVER_URL`.