### PR TITLE
Fixed regex matching for K8s Containerd

### DIFF
--- a/config/examples/kubernetes-containerd-log-routing.yml
+++ b/config/examples/kubernetes-containerd-log-routing.yml
@@ -16,10 +16,16 @@ inputFilter:
 #       include: !!js/regexp /failed|error|exception/i # include errors
 #       exclude: !!js/regexp /super noisy error messages/i # exclude noise
 
+outputFilter:
+  kubernetesEnrichment: 
+    module: kuberntes-enrichment
+
 output:
+  # stdout: ldjson
   elasticsearch:
     module: elasticsearch
     url: https://logsene-receiver.sematext.com
+    # index: de1135be-xxxx-xxxx-xxxx-365c63d5aff2
     indices: 
       c332463a-xxxx-xxxx-xxxx-535d18521418: 
         - app.*\.log

--- a/lib/plugins/input-filter/kubernetesContainerd.js
+++ b/lib/plugins/input-filter/kubernetesContainerd.js
@@ -94,6 +94,7 @@ module.exports = function (context, config, data, callback) {
         }
         sources[sourceName].streamFlag = k8sInfo.streamFlag
 
+        // if it is a partial return and wait for the next chunk
         if (sources[sourceName].streamFlag === 'P') {
           if (sources[sourceName].logLines === undefined) {
             sources[sourceName].logLines = []
@@ -105,6 +106,7 @@ module.exports = function (context, config, data, callback) {
           return callback(null, null)
         }
 
+        // if it is the final chunk of the partial log join it and ship it
         if (
           sources[sourceName].streamFlag === 'F' &&
           sources[sourceName].previousStreamFlag === 'P'
@@ -117,6 +119,16 @@ module.exports = function (context, config, data, callback) {
           // the parsed object after parsing -> all logs will be enriched k8s metadata
           context.enrichEvent = k8sInfo
           return callback(null, joinedLogLine)
+        }
+
+        // if it is a full log line, enrich it, and send as is
+        if (
+          sources[sourceName].streamFlag === 'F'
+        ) {
+          // a special property in context object to propagate fields to
+          // the parsed object after parsing -> all logs will be enriched k8s metadata
+          context.enrichEvent = k8sInfo
+          return callback(null, logLine)
         }
       }
 

--- a/lib/plugins/input-filter/kubernetesContainerd.js
+++ b/lib/plugins/input-filter/kubernetesContainerd.js
@@ -140,16 +140,3 @@ module.exports = function (context, config, data, callback) {
     return callback(null, data)
   }
 }
-
-// test function
-// if (require.main === module) {
-//   module.exports(
-//     {
-//       sourceName:
-//         '/var/log/containers/busybox2_default_busybox-5f03725b871fe3f2cbfdde7864100a12aed2708d759bea14f8d41656accba8f6.log'
-//     },
-//     {},
-//     '2019-03-28T23:13:41.945317977Z stdout F Mar 28 23:13:41 kube-mil01-pa1934121294964badacb5ddd3753d504c-w1 local1.notice haproxy[8]: Proxy masteretcdfrontend started',
-//     console.log
-//   )
-// }

--- a/lib/plugins/input-filter/kubernetesContainerd.js
+++ b/lib/plugins/input-filter/kubernetesContainerd.js
@@ -1,4 +1,5 @@
-const containerdSplitRegexp = /^(.+[stdout|stderr] [F|P]) /
+// const containerdSplitRegexp = /^(.+[stdout|stderr] [F|P]) / // old
+const containerdSplitRegexp = /^(.+)\s(stdout|stderr)\s(F|P)\s(.*)/ // new
 
 // Dictionary to store sources and log lines
 /**
@@ -62,17 +63,30 @@ function parseK8sFileName (sourceName) {
 }
 
 module.exports = function (context, config, data, callback) {
+  console.log('debug 1:', data)
+
   try {
     const sections = data.split(containerdSplitRegexp)
-    if (sections && sections.length === 3) {
-      const k8sInfo = parseK8sFileName(context.sourceName)
-      const meta = sections[1].split(' ')
-      const logLine = sections[2]
+    console.log('debug 2:', sections)
+    console.log('debug 3:', sections.length)
 
-      if (meta.length === 3 && meta[0]) {
-        k8sInfo['@timestamp'] = new Date(meta[0])
-        k8sInfo.streamName = meta[1]
-        k8sInfo.streamFlag = meta[2]
+    if (sections && sections.length === 6) {
+      const k8sInfo = parseK8sFileName(context.sourceName)
+      const timestamp = sections[1]
+      const streamName = sections[2]
+      const streamFlag = sections[3]
+      const logLine = sections[4]
+
+      console.log('debug 4: k8sInfo', k8sInfo)
+      console.log('debug 5: timestamp', timestamp)
+      console.log('debug 6: streamName', streamName)
+      console.log('debug 7: streamFlag', streamFlag)
+      console.log('debug 8: logLine', logLine)
+
+      if (timestamp && streamName && streamFlag) {
+        k8sInfo['@timestamp'] = new Date(timestamp)
+        k8sInfo.streamName = streamName
+        k8sInfo.streamFlag = streamFlag
 
         const sourceName = context.sourceName
         if (sources[sourceName] === undefined) {

--- a/lib/plugins/input-filter/kubernetesContainerd.js
+++ b/lib/plugins/input-filter/kubernetesContainerd.js
@@ -63,12 +63,8 @@ function parseK8sFileName (sourceName) {
 }
 
 module.exports = function (context, config, data, callback) {
-  console.log('debug 1:', data)
-
   try {
     const sections = data.split(containerdSplitRegexp)
-    console.log('debug 2:', sections)
-    console.log('debug 3:', sections.length)
 
     if (sections && sections.length === 6) {
       const k8sInfo = parseK8sFileName(context.sourceName)
@@ -76,12 +72,6 @@ module.exports = function (context, config, data, callback) {
       const streamName = sections[2]
       const streamFlag = sections[3]
       const logLine = sections[4]
-
-      console.log('debug 4: k8sInfo', k8sInfo)
-      console.log('debug 5: timestamp', timestamp)
-      console.log('debug 6: streamName', streamName)
-      console.log('debug 7: streamFlag', streamFlag)
-      console.log('debug 8: logLine', logLine)
 
       if (timestamp && streamName && streamFlag) {
         k8sInfo['@timestamp'] = new Date(timestamp)


### PR DESCRIPTION
This PR fixes:

- [x] Regex matching when a log message has a `|` (pipe) symbol
- [x] Log enrichment for all K8s Containerd logs