### PR TITLE
Output Filter for renaming fields

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -80,6 +80,7 @@ var moduleAlias = {
   'aes-encrypt-fields': '../lib/plugins/output-filter/aes-encrypt-fields.js',
   'ip-truncate-fields': '../lib/plugins/output-filter/ip-truncate-fields.js',
   'remove-fields': '../lib/plugins/output-filter/remove-fields.js',
+  'rename-fields': '../lib/plugins/output-filter/rename-fields.js',
   'drop-events': '../lib/plugins/output-filter/dropEventsFilter.js',
   'docker-enrichment': '../lib/plugins/output-filter/docker-log-enrichment.js',
   'kubernetes-enrichment':

--- a/config/examples/output-filter-rename-fields.yml
+++ b/config/examples/output-filter-rename-fields.yml
@@ -1,0 +1,13 @@
+outputFilter:
+  rename-fields:
+    module: rename-fields
+    # JS regular expression to match log source name
+    matchSource: !!js/regexp .*
+    fields:
+      - fieldName: user
+        renameTo: user_object
+
+# Exmple, input: 
+# {"user": "{ name: root }", "message": "Client connect: root", "originalLine": "INFO Client connect: root"}
+# Example, output
+# {"user_object": "{ name: root }", "message": "Client connect: root", "originalLine": "INFO Client connect: root"}

--- a/lib/plugins/output-filter/rename-fields.js
+++ b/lib/plugins/output-filter/rename-fields.js
@@ -1,0 +1,27 @@
+const get = require('get-value')
+const unset = require('unset-value')
+const set = require('set-value')
+
+function renameFields (context, config, eventEmitter, data, callback) {
+  if (data === undefined) {
+    return callback(new Error('data is null'), null)
+  }
+  try {
+    if (!config.matchSource.test(context.sourceName || data.logSource)) {
+      return callback(null, data)
+    }
+
+    const fields = config.fields
+    fields.forEach(field => {
+      const { fieldName, renameTo } = field
+      const fieldValue = get(data, fieldName)
+      unset(data, fieldName)
+      set(data, renameTo, fieldValue)
+    })
+
+    callback(null, data)
+  } catch (ex) {
+    callback(ex, null)
+  }
+}
+module.exports = renameFields


### PR DESCRIPTION
This PR adds an output filter for renaming fields in log lines.

Eg.
```yaml
outputFilter:
  rename-fields:
    module: rename-fields
    # JS regular expression to match log source name
    matchSource: !!js/regexp .*
    fields:
      - fieldName: user
        renameTo: user_object
```
This will rename the the `user` field into `user_object`.

Example:

Input
```json
{"user": "{ name: root }", "message": "Client connect: root", "originalLine": "INFO Client connect: root"}
```

Output
```json
{"user_object": "{ name: root }", "message": "Client connect: root", "originalLine": "INFO Client connect: root"}
```