### PR TITLE
SC-9192: Fixing "closed prematurely" Elasticsearch error response

### DIFF
--- a/lib/plugins/output-filter/github-logs-format.js
+++ b/lib/plugins/output-filter/github-logs-format.js
@@ -36,7 +36,7 @@ const initAuthorMessage = ({ senderName, senderUrl }) =>
 
 const parseEventTitle = ({ event }) => event.replace(/_/g, ' ')
 
-const parseReleaseTextFields = ({ field }) => field.replace(/\+/g, ' ')
+const parseTextFields = ({ field }) => field.replace(/\+/g, ' ')
 
 const capitalize = s => {
   if (typeof s !== 'string') return ''
@@ -151,8 +151,8 @@ const parseIssue = (event, body) => {
   const parsedIssue = {
     url: issue.html_url,
     number: issue.number,
-    title: issue.title,
-    body: issue.body,
+    title: parseTextFields({ field: issue.title }),
+    body: parseTextFields({ field: issue.body }),
     state: issue.state,
     commentCount: issue.comments,
     createdAt: issue.created_at,
@@ -201,8 +201,8 @@ const parsePullRequest = (event, body) => {
   const parsedPullRequest = {
     url: pullRequest.html_url,
     number: pullRequest.number,
-    title: pullRequest.title,
-    body: pullRequest.body,
+    title: parseTextFields({ field: pullRequest.title }),
+    body: parseTextFields({ field: pullRequest.body }),
     state: pullRequest.state,
     commentCount: pullRequest.comments,
     createdAt: pullRequest.created_at,
@@ -251,7 +251,7 @@ const parseCommitComment = (event, body) => {
   const parsedComment = {
     commitId: comment.commit_id,
     url: comment.html_url,
-    body: comment.body,
+    body: parseTextFields({ field: comment.body }),
     line: comment.line,
     path: comment.path,
     position: comment.position,
@@ -401,8 +401,8 @@ const parseRelease = (event, body) => {
   const parsedRelease = {
     url,
     tag,
-    name: parseReleaseTextFields({ field: name }),
-    body: parseReleaseTextFields({ field: releaseBody }),
+    name: parseTextFields({ field: name }),
+    body: parseTextFields({ field: releaseBody }),
     branch,
     draft,
     author: { username: authorUsername },

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -134,8 +134,14 @@ OutputElasticsearch.prototype.getLogger = function (
           formatObject(err) +
           ' / ' +
           formatObject(err.err)
-        this.eventEmitter.emit('error', errorMessage)
+
         logger.emit('error', errorMessage)
+      }.bind(this)
+    )
+    logger.on(
+      'error',
+      function (errorMessage) {
+        this.eventEmitter.emit('error', errorMessage)
       }.bind(this)
     )
     logger.on(

--- a/lib/plugins/output/elasticsearch.js
+++ b/lib/plugins/output/elasticsearch.js
@@ -135,6 +135,7 @@ OutputElasticsearch.prototype.getLogger = function (
           ' / ' +
           formatObject(err.err)
         this.eventEmitter.emit('error', errorMessage)
+        logger.emit('error', errorMessage)
       }.bind(this)
     )
     logger.on(


### PR DESCRIPTION
This PR fixes the following errors:

```bash
upstream prematurely closed connection while reading response header from upstream
```

```bash
recv() failed (104: Connection reset by peer) while reading response header from upstream
```

I think this was caused by the `EventEmitter` sending and closing events asynchronously which in turn caused some requests to be closed prematurely.
