### PR TITLE
Lowercase multiline journal fields as well

### DIFF
--- a/lib/plugins/input/journald-upload.js
+++ b/lib/plugins/input/journald-upload.js
@@ -30,7 +30,7 @@ class Parser {
       return
     }
     this.multiLineMode = true
-    this.multiLineFieldName = data
+    this.multiLineFieldName = data.toLowerCase()
     this.multiLineFieldValue = ''
   }
 


### PR DESCRIPTION
I assume this is a bug where all fields are lowercased, except the "multiline" ones. This is hard to be consistent with the JSON output of `journalctl`, where some newlines are stripped (e.g. `SELINUX_CONTEXT`). We should simply lowercase everything.