### PR TITLE
Hotfix: Fix for K8s enrichment dropping logs

### DIFF
--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -216,6 +216,9 @@ function processAnnotations (
     checkLogsReceiverUrl(pod, data, context)
     return callback(null, data)
   }
+
+  // fallback to return data if no pod info found
+  return callback(null, data)
 }
 
 function getPodCacheKey (data) {

--- a/lib/plugins/output-filter/kubernetes-enrichment.js
+++ b/lib/plugins/output-filter/kubernetes-enrichment.js
@@ -49,13 +49,13 @@ function kubernetesOutputFilter (
 ) {
   // we use the config object to track state of each plugin instance
   if (!config.client) {
-    initKubernetesClient(config)
+    initKubernetesClient(context, config, eventEmitter, data, callback)
   } else {
     enrichLogs(context, config, eventEmitter, data, callback)
   }
 }
 
-function initKubernetesClient (config) {
+function initKubernetesClient (context, config, eventEmitter, data, callback) {
   // do we run in k8s cluster?
   config.client = client
   config.getPodSpec = function (namespace, podName, cb) {
@@ -64,6 +64,8 @@ function initKubernetesClient (config) {
       .pods(podName)
       .get(cb)
   }.bind(config)
+
+  enrichLogs(context, config, eventEmitter, data, callback)
 }
 
 const getPodSpec = async (config, namespace, podName, cb) => {


### PR DESCRIPTION
The K8s enrichment filter had a bug and dropped the first couple of initial logs when is just started. This PR fixes this and now the logs are not dropped.