### PR TITLE
made colon optional for authentication messages

### DIFF
--- a/patterns.yml
+++ b/patterns.yml
@@ -712,7 +712,7 @@ patterns:
       - vhost:string
      dateFormat: yyyy-MM-dd HH:mm:ss.SSS
    - type: rabbitmq_connections_vhost_user
-     regex: !!js/regexp /^(\S+\s\S+)\s\[(\S+)\]\s<(\S+)>\s(accepting|closing)\sAMQP\sconnection\s<\S+>\s\((\S+):(\d+)\s->\s(\S+):(\d+),\svhost:\s'(.+)',\suser:\s'(.+)'\)([\s\S]*)/
+     regex: !!js/regexp /^(\S+\s\S+)\s\[(\S+)\]\s<(\S+)>\s(accepting|closing)\sAMQP\sconnection\s<\S+>\s\((\S+):(\d+)\s->\s(\S+):(\d+),\svhost:\s'(.+)',\suser:\s'(.+)'\):?([\s\S]*)/
      fields:
       - ts
       - severity


### PR DESCRIPTION
Applies to something like:

```
2020-09-19 16:48:35.931 [warning] <0.1429.0> closing AMQP connection <0.1429.0> (127.0.0.1:54326 -> 127.0.0.1:5672, vhost: '/', user: 'guest'):
client unexpectedly closed TCP connection
```

Where the `message` would begin with `:` and it would look ugly.