### PR TITLE
Make default journald config easier to extend

### DIFF
--- a/bin/logagent-setup.sh
+++ b/bin/logagent-setup.sh
@@ -305,13 +305,13 @@ outputFilter:
   lowercase-fields:
     module: lowercase-fields
     # JS regular expression to match log source name
-    matchSource: !!js/regexp .*
+    matchSource: !!js/regexp journald
     allFields: true
 
   removeFields:
     module: remove-fields
     # JS regular expression to match log source name
-    matchSource: !!js/regexp .*
+    matchSource: !!js/regexp journald
     # Note: journald format converts to lower case
     fields:
       - __cursor
@@ -323,8 +323,10 @@ output:
   elasticsearch: 
     module: elasticsearch
     url: $LOGSENE_RECEIVER_URL
-    # default index (Logs token) to use:
-    index: $TOKEN
+    # default index (Logs token) to use for journald logs:
+    indices:
+      $TOKEN:
+        - journald
 " > $SPM_AGENT_CONFIG_FILE
 else
 echo -e \


### PR DESCRIPTION
I'm trying to make it easier to add new sources (and new app destinations), once this "system" config is in place.

This commit will only remove fields if we match the `journald` source, and the same with the output. Ideally, we'd do the same for the `journald-format` filter, but I don't know how to do that (besides patching the filter itself). It seems to work for now, so I'll leave it as is.