### PR TITLE
Add aws-ecs input and output filter

### DIFF
--- a/bin/logagent.js
+++ b/bin/logagent.js
@@ -65,6 +65,7 @@ var moduleAlias = {
   'docker-logs': '../lib/plugins/input/docker/docker.js',
   'input-github-webhook': '../lib/plugins/input/webhooks/github.js',
   'input-vercel': '../lib/plugins/input/vercel.js',
+  'input-aws-ecs': '../lib/plugins/input/aws-ecs.js',
   'azure-event-hub': '../lib/plugins/input/azure-event-hub.js',
   'unix-socket-reader': '../lib/plugins/input/unixSocketReader.js',
   // input filters
@@ -94,6 +95,7 @@ var moduleAlias = {
     '../lib/plugins/output-filter/github-events-format.js',
   'github-logs-format': '../lib/plugins/output-filter/github-logs-format.js',
   'vercel-format': '../lib/plugins/output-filter/vercel-format.js',
+  'aws-ecs-format': '../lib/plugins/output-filter/aws-ecs-format.js',
   // output plugins
   elasticsearch: '../lib/plugins/output/elasticsearch.js',
   'slack-webhook': '../lib/plugins/output/slack-webhook.js',

--- a/config/examples/aws-ecs-input-es-output.yml
+++ b/config/examples/aws-ecs-input-es-output.yml
@@ -1,0 +1,20 @@
+debug: false
+
+input:
+  vercel:
+    module: input-aws-ecs
+    port: 6666
+    useIndexFromUrlPath: true
+    # workers: 4
+
+      
+outputFilter: 
+  aws-ecs-format: 
+    module: aws-ecs-format
+
+output: 
+  stdout: yaml
+    
+  # sematext-cloud:
+  #   module: elasticsearch
+  #   url: https://logsene-receiver.sematext.com

--- a/config/examples/aws-ecs-input-es-output.yml
+++ b/config/examples/aws-ecs-input-es-output.yml
@@ -1,20 +1,23 @@
-debug: false
+debug: true
 
 input:
-  vercel:
+  input-aws-ecs:
     module: input-aws-ecs
     port: 6666
     useIndexFromUrlPath: true
+    # debug: true
     # workers: 4
-
       
 outputFilter: 
   aws-ecs-format: 
     module: aws-ecs-format
+    parseMessageField: true
+    # debug: true
 
 output: 
-  stdout: yaml
+  # debug: true
+  # stdout: yaml
     
-  # sematext-cloud:
-  #   module: elasticsearch
-  #   url: https://logsene-receiver.sematext.com
+  sematext-cloud:
+    module: elasticsearch
+    url: https://logsene-receiver.sematext.com

--- a/lib/plugins/input/aws-ecs.js
+++ b/lib/plugins/input/aws-ecs.js
@@ -93,8 +93,10 @@ class AwsEcs {
     if (docs && docs.length > 0) {
       for (let i = 0; i < docs.length; i++) {
         const log = docs[i]
-        log['@timestamp'] = new Date(log.timestamp)
-        delete log.timestamp
+        log['@timestamp'] = new Date()
+        delete log.date
+        log.message = log.log
+        delete log.log
 
         self.emitEvent(log, token)
       }

--- a/lib/plugins/input/aws-ecs.js
+++ b/lib/plugins/input/aws-ecs.js
@@ -1,0 +1,188 @@
+const consoleLogger = require('../../util/logger.js')
+const http = require('http')
+const throng = require('throng')
+const extractTokenRegEx = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+const tokenFormatRegEx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+const TokenBlacklist = require('../../util/token-blacklist.js')
+
+class AwsEcs {
+  constructor (config, eventEmitter) {
+    this.config = config
+    this.eventEmitter = eventEmitter
+    this.tokenBlackList = new TokenBlacklist(eventEmitter)
+    if (config.workers) {
+      this.config.workers = config.workers
+    } else {
+      this.config.workers = 0
+    }
+  }
+
+  start () {
+    if (this.config.workers && this.config.workers > 0) {
+      throng(
+        {
+          workers: this.config.workers,
+          lifetime: Infinity
+        },
+        this.startAwsEcs.bind(this)
+      )
+    } else {
+      this.startAwsEcs(1)
+    }
+  }
+
+  stop (cb) {
+    cb()
+  }
+
+  emitEvent (log, token) {
+    this.addTags(log)
+    const context = { name: 'ecs', sourceName: 'ecs' }
+    if (token) {
+      context.index = token
+    }
+    this.eventEmitter.emit('data.object', log, context)
+  }
+
+  addTags (log) {
+    if (this.config.tags === undefined) {
+      return
+    }
+    const keys = Object.keys(this.config.tags)
+    for (let i = 0; i < keys.length; i++) {
+      // avoid setting _index when passed in URL
+      if (log[keys[i]] === undefined) {
+        log[keys[i]] = this.config.tags[keys[i]]
+      }
+    }
+  }
+
+  getHttpServer (aport, handler) {
+    let _port = aport || process.env.PORT || 8400
+    if (aport === true) {
+      _port = process.env.PORT
+    }
+
+    let server = http.createServer(handler)
+    // Increase the connection timeout to equal the Nginx Ingress timeout of 1min.
+    server.on('connection', socket => socket.setTimeout(60 * 1000))
+
+    try {
+      const bindAddress = this.config.bindAddress || '0.0.0.0'
+      server = server.listen(_port, bindAddress)
+      consoleLogger.log(
+        'Logagent listening (HTTP ECS): ' +
+          bindAddress +
+          ':' +
+          _port +
+          ', process id: ' +
+          process.pid
+      )
+      return server
+    } catch (err) {
+      consoleLogger.log('Port in use ECS (' + _port + '): ' + err)
+    }
+  }
+
+  parseBody (body, token) {
+    if (body.length === 0) {
+      return
+    }
+    const self = this
+    const docs = JSON.parse(body)
+    if (docs && docs.length > 0) {
+      for (let i = 0; i < docs.length; i++) {
+        const log = docs[i]
+        log['@timestamp'] = new Date(log.timestamp)
+        delete log.timestamp
+
+        self.emitEvent(log, token)
+      }
+    } else {
+      // unknow structure, let's index the doc to ease trouble shooting
+      self.emitEvent(docs, token)
+    }
+  }
+
+  HttpHandler (req, res) {
+    try {
+      const self = this
+      const path = req.url.split('/')
+      let token = null
+      let bodyIn = ''
+      if (self.config.useIndexFromUrlPath === true && path.length > 1) {
+        if (path[1] && path[1].length > 31 && tokenFormatRegEx.test(path[1])) {
+          const match = path[1].match(extractTokenRegEx)
+          if (match && match.length > 1) {
+            token = match[1]
+          }
+        } else if (path[1] === 'health' || path[1] === 'ping') {
+          res.statusCode = 200
+          res.end('ok\n')
+          return
+        }
+      }
+      if (
+        (self.config.useIndexFromUrlPath === true && !token) ||
+        self.tokenBlackList.isTokenInvalid(token)
+      ) {
+        res.statusCode = self.config.invalidTokenStatus || 403
+        res.end(`invalid logs token in url ${req.url}`)
+        return
+      }
+      req.on('data', function (data) {
+        bodyIn += String(data)
+      })
+      req.on('end', function endHandler () {
+        try {
+          self.parseBody(bodyIn, token)
+        } catch (err) {
+          if (self.config.debug) {
+            consoleLogger.error('Error in ECS HttpHandler: ' + err)
+          }
+
+          res.writeHead(500, { 'Content-Type': 'text/plain' })
+          res.end(`Invalid json input: ${err}\n`)
+          return
+        }
+        // send response to client
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('OK\n')
+      })
+    } catch (err) {
+      res.statusCode = 500
+      res.end()
+      consoleLogger.error('Error in ECS HttpHandler: ' + err)
+    }
+  }
+
+  startAwsEcs (id) {
+    this.getHttpServer(Number(this.config.port), this.HttpHandler.bind(this))
+    let exitInProgress = false
+    const terminate = function terminate (reason) {
+      return function () {
+        if (exitInProgress) {
+          return
+        }
+        exitInProgress = true
+        consoleLogger.log(
+          'Stop ECS HTTP worker: ' +
+            id +
+            ', pid:' +
+            process.pid +
+            ', terminate reason: ' +
+            reason +
+            ' memory rss: ' +
+            (process.memoryUsage().rss / (1024 * 1024)).toFixed(2) +
+            ' MB'
+        )
+        setTimeout(process.exit, 250)
+      }
+    }
+    process.once('SIGTERM', terminate('SIGTERM'))
+    process.once('SIGINT', terminate('SIGINT'))
+    process.once('exit', terminate('exit'))
+  }
+}
+
+module.exports = AwsEcs

--- a/lib/plugins/input/aws-ecs.js
+++ b/lib/plugins/input/aws-ecs.js
@@ -37,7 +37,10 @@ class AwsEcs {
 
   emitEvent (log, token) {
     this.addTags(log)
-    const context = { name: 'ecs', sourceName: 'ecs' }
+    const context = {
+      name: 'ecs',
+      sourceName: 'ecs'
+    }
     if (token) {
       context.index = token
     }
@@ -84,10 +87,17 @@ class AwsEcs {
     }
   }
 
-  parseBody (body, token) {
+  parseSourceName (headers) {
+    if (!!headers && !!headers.sourcename) {
+      return headers.sourcename
+    }
+  }
+
+  parseRes (headers, body, token) {
     if (body.length === 0) {
       return
     }
+
     const self = this
     const docs = JSON.parse(body)
     if (docs && docs.length > 0) {
@@ -97,6 +107,11 @@ class AwsEcs {
         delete log.date
         log.message = log.log
         delete log.log
+
+        const sourceName = self.parseSourceName(headers)
+        if (sourceName) {
+          log.sourceName = sourceName
+        }
 
         self.emitEvent(log, token)
       }
@@ -137,7 +152,7 @@ class AwsEcs {
       })
       req.on('end', function endHandler () {
         try {
-          self.parseBody(bodyIn, token)
+          self.parseRes(req.headers, bodyIn, token)
         } catch (err) {
           if (self.config.debug) {
             consoleLogger.error('Error in ECS HttpHandler: ' + err)

--- a/lib/plugins/input/aws-ecs.js
+++ b/lib/plugins/input/aws-ecs.js
@@ -61,7 +61,7 @@ class AwsEcs {
   }
 
   getHttpServer (aport, handler) {
-    let _port = aport || process.env.PORT || 8400
+    let _port = aport || process.env.PORT || 6666
     if (aport === true) {
       _port = process.env.PORT
     }

--- a/lib/plugins/output-filter/aws-ecs-format.js
+++ b/lib/plugins/output-filter/aws-ecs-format.js
@@ -1,0 +1,37 @@
+function jsonParse (text) {
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    return null
+  }
+}
+
+function extractJson (line, source) {
+  let parsed = {}
+  if (/^\[{0,1}\{.*\}]{0,1}$/.test(line)) {
+    parsed = jsonParse(line)
+    if (!parsed) {
+      return null
+    }
+    return parsed
+  }
+}
+
+function formatAwsEcs (context, config, eventEmitter, log, callback) {
+  try {
+    const parsedLog = parseAwsEcs(log, context)
+
+    return callback(null, parsedLog)
+  } catch (err) {
+    console.log(err)
+    return callback(null, log)
+  }
+}
+
+function parseAwsEcs (log, context) {
+  console.log(log)
+
+  return log
+}
+
+module.exports = formatAwsEcs

--- a/lib/plugins/output-filter/aws-ecs-format.js
+++ b/lib/plugins/output-filter/aws-ecs-format.js
@@ -1,6 +1,11 @@
 const Parser = require('../../parser/parser.js')
 const logParser = new Parser()
 
+const SEVERITY = {
+  stderr: 'err',
+  stdout: 'info'
+}
+
 function jsonParse (text) {
   try {
     return JSON.parse(text)
@@ -10,32 +15,78 @@ function jsonParse (text) {
 }
 
 function extractJson (line, source) {
-  let parsed = {}
   if (/^\[{0,1}\{.*\}]{0,1}$/.test(line)) {
+    let parsed = {}
     parsed = jsonParse(line)
     if (!parsed) {
       return null
     }
     return parsed
   }
+  return null
+}
+
+function parseJsonLog (log) {
+  const jsonLog = extractJson(log.message)
+  if (!jsonLog) {
+    return null
+  }
+
+  if (jsonLog && jsonLog.message) {
+    delete log.message
+  }
+  return {
+    ...jsonLog,
+    ...log
+  }
 }
 
 function formatAwsEcs (context, config, eventEmitter, log, callback) {
   try {
+
+    log.severity = SEVERITY[log.source]
+    log.source = log.sourceName
+    delete log.sourceName
+
+    // check if log.message is in JSON format, return parsed log object or null
+    const parsedLog = parseJsonLog(log)
+    if (parsedLog) {
+      // if not null, the log is parsed, structured and sent down the pipeline
+      return callback(null, parsedLog)
+    }
+
+    //
+    //
+    //
+    //
+
     // optional parsing of message field with logagent patterns
-    if (config.parseMessageField === true && log.message !== undefined) {
-      logParser.parseLine(log.message, log.sourceName, function (err, data) {
+    if (log.message !== undefined) {
+      logParser.parseLine(log.message, log.source, function (err, data) {
         if (err) {
           return callback(err, log)
         }
 
         if (data && data._type) {
+          // console.log('\n')
+          // console.log('\n')
+          // console.log(data)
+          // console.log('\n')
+          // console.log('\n')
+
           const type = `${data._type}`
           delete data['@timestamp']
           delete data.logSource
           delete data._type
+          log.type = type
           log[type] = {}
           Object.assign(log[type], data)
+
+          console.log('\n')
+          console.log('\n')
+          console.log(log)
+          console.log('\n')
+          console.log('\n')
         }
         return callback(null, log)
       })

--- a/lib/plugins/output-filter/aws-ecs-format.js
+++ b/lib/plugins/output-filter/aws-ecs-format.js
@@ -43,7 +43,6 @@ function parseJsonLog (log) {
 
 function formatAwsEcs (context, config, eventEmitter, log, callback) {
   try {
-
     log.severity = SEVERITY[log.source]
     log.source = log.sourceName
     delete log.sourceName
@@ -55,12 +54,10 @@ function formatAwsEcs (context, config, eventEmitter, log, callback) {
       return callback(null, parsedLog)
     }
 
-    //
-    //
-    //
-    //
-
-    // optional parsing of message field with logagent patterns
+    // if the log.message is not in JSON format then
+    // we parse the log.message field with logagent patterns
+    // using the log.source as the pattern sourceName (check patterns.yml)
+    // for for more info
     if (log.message !== undefined) {
       logParser.parseLine(log.message, log.source, function (err, data) {
         if (err) {
@@ -68,12 +65,6 @@ function formatAwsEcs (context, config, eventEmitter, log, callback) {
         }
 
         if (data && data._type) {
-          // console.log('\n')
-          // console.log('\n')
-          // console.log(data)
-          // console.log('\n')
-          // console.log('\n')
-
           const type = `${data._type}`
           delete data['@timestamp']
           delete data.logSource
@@ -81,12 +72,6 @@ function formatAwsEcs (context, config, eventEmitter, log, callback) {
           log.type = type
           log[type] = {}
           Object.assign(log[type], data)
-
-          console.log('\n')
-          console.log('\n')
-          console.log(log)
-          console.log('\n')
-          console.log('\n')
         }
         return callback(null, log)
       })

--- a/lib/plugins/output-filter/aws-ecs-format.js
+++ b/lib/plugins/output-filter/aws-ecs-format.js
@@ -1,3 +1,6 @@
+const Parser = require('../../parser/parser.js')
+const logParser = new Parser()
+
 function jsonParse (text) {
   try {
     return JSON.parse(text)
@@ -19,19 +22,30 @@ function extractJson (line, source) {
 
 function formatAwsEcs (context, config, eventEmitter, log, callback) {
   try {
-    const parsedLog = parseAwsEcs(log, context)
+    // optional parsing of message field with logagent patterns
+    if (config.parseMessageField === true && log.message !== undefined) {
+      logParser.parseLine(log.message, log.sourceName, function (err, data) {
+        if (err) {
+          return callback(err, log)
+        }
 
-    return callback(null, parsedLog)
+        if (data && data._type) {
+          const type = `${data._type}`
+          delete data['@timestamp']
+          delete data.logSource
+          delete data._type
+          log[type] = {}
+          Object.assign(log[type], data)
+        }
+        return callback(null, log)
+      })
+    }
+
+    return callback(null, log)
   } catch (err) {
     console.log(err)
-    return callback(null, log)
+    return callback(err, log)
   }
-}
-
-function parseAwsEcs (log, context) {
-  console.log(log)
-
-  return log
 }
 
 module.exports = formatAwsEcs


### PR DESCRIPTION
This PR adds:
- [x] input plugin for AWS ECS - An HTTP server that will act as a log drain receiver for JSON formatted logs sent through HTTPS from AWS FireLens with FluentBit. 
- [x] output filter to AWS ECS - A filter for parsing raw message field patterns that Logagent supports out-of-the box, as well as destructuring JSON message fields into root-level fields.