### PR TITLE
input-journald-upload: use removeFields from config, fix include/exclude test

### DIFF
--- a/lib/plugins/input/journald-upload.js
+++ b/lib/plugins/input/journald-upload.js
@@ -12,9 +12,10 @@ const keyValueFieldRegex = /^\S+=.+$/ // key=value
 const cursorRegex = /^__CURSOR=/
 // const exportRecordRegex = /^(\S+)=(.+)$|^(\S+)$\n$\n([\S|\s]+)\n$/gm
 class Parser {
-  constructor (emitEvent, token) {
+  constructor (emitEvent, token, removeFields) {
     this.token = token
     this.emitEvent = emitEvent
+    this.removeFields = removeFields
     this.multiLineMode = false
     this.log = {}
     this.multiLineFieldValue = ''
@@ -46,7 +47,7 @@ class Parser {
     if (!isNaN(value)) {
       value = Number(value)
     }
-    if (fieldName.length > 0) {
+    if (fieldName.length > 0 && !this.removeFields[fieldName]) {
       this.log[fieldName] = value
     }
   }
@@ -175,17 +176,19 @@ JournaldUpload.prototype.emitEvent = function (log, token) {
     if (
       config.systemdUnitFilter !== undefined &&
       config.systemdUnitFilter.include &&
-      !config.systemdUnitFilter.include.test(log._SYSTEMD_UNIT)
+      !config.systemdUnitFilter.include.test(systemdUnit)
     ) {
       return
     }
     if (
       config.systemdUnitFilter !== undefined &&
       config.systemdUnitFilter.exclude &&
-      config.systemdUnitFilter.exclude.test(log._SYSTEMD_UNIT)
+      config.systemdUnitFilter.exclude.test(systemdUnit)
     ) {
       return
     }
+  } else {
+    // ignore messages not from systemd
   }
   const context = {
     sourceName: log[_SYSTEMD_UNIT] || log[SYSLOG_IDENTIFIER] || 'journald',
@@ -239,22 +242,6 @@ JournaldUpload.prototype.getHttpServer = function (aport, handler) {
   }
 }
 
-JournaldUpload.prototype.parseLine = function (log, line) {
-  if (!line) {
-    return log
-  }
-  const index = line.indexOf('=')
-  const fieldName = line.substr(0, index).toLowerCase()
-  let value = line.substr(index + 1, line.length)
-  if (!isNaN(value)) {
-    value = Number(value)
-  }
-  if (!this.removeFields[fieldName]) {
-    log[fieldName] = value
-  }
-  return log
-}
-
 JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
   try {
     this.config.useIndexFromUrlPath = true
@@ -262,7 +249,7 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
     const path = req.url.split('/')
     let token = null
 
-    if (self.config.useIndexFromUrlPath === true && path.length > 1) {
+    if (this.config.useIndexFromUrlPath === true && path.length > 1) {
       if (path[1] && path[1].length > 31 && tokenFormatRegEx.test(path[1])) {
         const match = path[1].match(extractTokenRegEx)
         if (match && match.length > 1) {
@@ -276,15 +263,15 @@ JournaldUpload.prototype.journaldHttpHandler = function (req, res) {
     }
 
     if (
-      (self.config.useIndexFromUrlPath === true && !token) ||
-      self.tokenBlackList.isTokenInvalid(token)
+      (this.config.useIndexFromUrlPath === true && !token) ||
+      this.tokenBlackList.isTokenInvalid(token)
     ) {
-      res.statusCode = self.config.invalidTokenStatus || 403
+      res.statusCode = this.config.invalidTokenStatus || 403
       res.end(`invalid logs token in url ${req.url}\n`)
       return
     }
 
-    const parserState = new Parser(self.emitEvent.bind(self), token)
+    const parserState = new Parser(this.emitEvent.bind(this), token, this.removeFields)
     req
       .pipe(createStreamThrottle(this.throughputPerClient))
       .pipe(split())


### PR DESCRIPTION
After some old refactoring in `64f435872178ea16357e4bcad13b3a3db63f6802` the function `parseLine` became unused and still in the code, moreover `removeFields` parameter from configuration was not working. This PR returns usage of `removeFields` as it was before the refactoring.

Also fixed a bug with include/exclude parameter (hint: `log._SYSTEMD_UNIT !== log[_SYSTEMD_UNIT]`).

And also ignore messages in journald not coming from systemd services (I had audit and kernel syslog messages flooding my logs). This is a questionable change applied only to my setup, so please review it.