### PR TITLE
Update azure-event-hub.js

### DIFF
--- a/lib/plugins/input/azure-event-hub.js
+++ b/lib/plugins/input/azure-event-hub.js
@@ -1,5 +1,5 @@
 'use strict'
-const { EventHubConsumerClient, EventPosition } = require('@azure/event-hubs')
+const { EventHubConsumerClient, latestEventPosition } = require('@azure/event-hubs')
 const consoleLogger = require('../../util/logger.js')
 /**
  *
@@ -70,7 +70,7 @@ InputAzureEventhub.prototype.startAsync = async function () {
     }
   }
   const subscriberOptions = {
-    eventPosition: EventPosition.fromEnqueuedTime(Date.now())
+    eventPosition: latestEventPosition
   }
   for (var p = 0; p < partitionIds.length; p++) {
     this.subscriptions.push(


### PR DESCRIPTION
Fixed azure event hub syntax to newer syntax. Issue was that '@azure/event-hubs' was using v5 version but old syntax for EventPosition.

![image](https://user-images.githubusercontent.com/1026038/129420549-50d1b3e8-e4a5-4f46-a870-a9293bfc39fe.png)
