### PR TITLE
[load-creds-from-ec2-role]

### DIFF
--- a/lib/plugins/output/aws-elasticsearch.js
+++ b/lib/plugins/output/aws-elasticsearch.js
@@ -20,30 +20,76 @@ output:
   awsConfigFile: ./aws-config.json
 */
 
+
+
+
 function OutputAwsElasticsearch (config, eventEmitter) {
-  this.config = config
-  this.eventEmitter = eventEmitter
-  // read global AWS settings if the plugin has no local AWS settings
-  var auth = config.auth
-  var awsConfigFile = config.awsConfigFile
-  if (!config.auth && config.configFile.aws && config.configFile.aws.auth) {
-    auth = config.configFile.aws.auth
-  }
-  if (
-    !config.awsConfigFile &&
-    config.configFile.aws &&
-    config.configFile.aws.awsConfigFile
-  ) {
-    awsConfigFile = config.configFile.aws.awsConfigFile
-  }
-  var esClientConfig = {
-    log: config.log,
-    host: config.url,
-    auth: auth,
-    connectionClass: config.awsConfigFile ? require('http-aws-es') : undefined,
-    awsConfig: AWS.config.loadFromPath(awsConfigFile)
-  }
-  this.client = new elasticsearch.Client(esClientConfig)
+
+  
+  AWS.config.getCredentials(function(err) {
+    if (err) {
+        console.log(err.stack);
+    }
+    else {
+
+      let aws_id = null;
+      let aws_secret = null;
+      // Loading configurations using the role attached to ec2 instance 
+      if (AWS.config.credentials.hasOwnProperty('accessKeyId')) {
+        console.log("Access Key:", AWS.config.credentials.accessKeyId);
+        aws_id = AWS.config.credentials.accessKeyId;
+      }
+      // if (AWS.config.credentials.metadata.hasOwnProperty('SecretAccessKey')) {
+      if (AWS.config.credentials.hasOwnProperty('metadata')) {
+        aws_secret = AWS.config.credentials.metadata.SecretAccessKey
+      }
+      
+      // if role is attached to ec2 instance
+      if ((aws_id) && (aws_secret)) {
+        aws_role_credentials = {
+          "accessKeyId": aws_id,
+          "secretAccessKey": aws_secret
+        }
+
+        var esClientConfig = {
+          log: config.log,
+          host: config.url,
+          auth: auth,
+          connectionClass: config.awsConfigFile ? require('http-aws-es') : undefined,
+          awsConfig: aws_role_credentials
+        }
+      } 
+
+      else {
+
+        this.config = config
+        this.eventEmitter = eventEmitter
+        // read global AWS settings if the plugin has no local AWS settings
+        
+        var auth = config.auth
+        var awsConfigFile = config.awsConfigFile
+        if (!config.auth && config.configFile.aws && config.configFile.aws.auth) {
+          auth = config.configFile.aws.auth
+        }
+        if (
+          !config.awsConfigFile &&
+          config.configFile.aws &&
+          config.configFile.aws.awsConfigFile
+        ) {
+          awsConfigFile = config.configFile.aws.awsConfigFile
+        }
+        var esClientConfig = {
+          log: config.log,
+          host: config.url,
+          auth: auth,
+          connectionClass: config.awsConfigFile ? require('http-aws-es') : undefined,
+          awsConfig: AWS.config.loadFromPath(awsConfigFile)
+        }
+      }
+      
+      this.client = new elasticsearch.Client(esClientConfig)
+        }
+      })
 }
 
 OutputAwsElasticsearch.prototype.eventHandler = function (data, context) {

--- a/lib/plugins/output/aws-elasticsearch.js
+++ b/lib/plugins/output/aws-elasticsearch.js
@@ -32,23 +32,23 @@ function OutputAwsElasticsearch (config, eventEmitter) {
     }
     else {
 
-      let aws_id = null;
-      let aws_secret = null;
+      let awsId = null;
+      let awsSecret = null;
       // Loading configurations using the role attached to ec2 instance 
       if (AWS.config.credentials.hasOwnProperty('accessKeyId')) {
         console.log("Access Key:", AWS.config.credentials.accessKeyId);
-        aws_id = AWS.config.credentials.accessKeyId;
+        awsId = AWS.config.credentials.accessKeyId;
       }
       // if (AWS.config.credentials.metadata.hasOwnProperty('SecretAccessKey')) {
       if (AWS.config.credentials.hasOwnProperty('metadata')) {
-        aws_secret = AWS.config.credentials.metadata.SecretAccessKey
+        awsSecret = AWS.config.credentials.metadata.SecretAccessKey
       }
       
       // if role is attached to ec2 instance
-      if ((aws_id) && (aws_secret)) {
-        aws_role_credentials = {
-          "accessKeyId": aws_id,
-          "secretAccessKey": aws_secret
+      if ((awsId) && (awsSecret)) {
+        awsRoleCredentials = {
+          "accessKeyId": awsId,
+          "secretAccessKey": awsSecret
         }
 
         var esClientConfig = {
@@ -56,7 +56,7 @@ function OutputAwsElasticsearch (config, eventEmitter) {
           host: config.url,
           auth: auth,
           connectionClass: config.awsConfigFile ? require('http-aws-es') : undefined,
-          awsConfig: aws_role_credentials
+          awsConfig: awsRoleCredentials
         }
       } 
 


### PR DESCRIPTION
update aws elasticsearch output plugin to load credentials from IAM role attached to an EC2 instance.

The PR belongs to this issue #286 


