### PR TITLE
SC-16333 Extract fields from vercel syslog messages

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -81,7 +81,7 @@
     "worker"        : false,    // Web Workers
     "wsh"           : false,    // Windows Scripting Host
     "yui"           : false,    // Yahoo User Interface
-    "esversion"     : 6,        // Disable JSHint from unnecessary warnings when code use ES6 syntax 
+    "esversion"     : 9,        // Disable JSHint from unnecessary warnings when code use ES6 syntax
   
 
     // Custom Globals

--- a/lib/plugins/output-filter/vercel-format.js
+++ b/lib/plugins/output-filter/vercel-format.js
@@ -58,8 +58,10 @@ function parseVercelLog (log) {
     initDuration.coldStart = true
     initDuration.initDuration = +lambdaVals[4].match(initDurationRegex)[1]
   }
+  const logDetails = extractLogDetails(message)
 
   return {
+    ...logDetails,
     message,
     duration,
     billedDuration,
@@ -119,6 +121,29 @@ function tryParseErrorLine (line) {
   } catch (e) {
     return line
   }
+}
+
+function extractLogDetails (logLine) {
+  const regex = /^START RequestId: (\S+) Version: (\S+)\n([^]+?)\t(\S+)\t(\S+)\t({(?:[^{}]|{[^{}]*})+})/ // Regular expression to match the log details
+
+  const match = logLine.match(regex) // Find the match of the regular expression in the log line
+
+  if (match) {
+    const requestId = match[1]
+    const version = match[2]
+    const timestamp = match[3]
+    const logLevel = match[5]
+    const message = match[6] // Get the JSON object string
+    return {
+      requestId,
+      version,
+      timestamp,
+      logLevel,
+      message
+    }
+  }
+
+  return { message: logLine } // Return unparsed if no log details are found in the log line
 }
 
 module.exports = formatVercelLogsOutput

--- a/lib/plugins/output-filter/vercel-format.js
+++ b/lib/plugins/output-filter/vercel-format.js
@@ -59,16 +59,26 @@ function parseVercelLog (log) {
     initDuration.initDuration = +lambdaVals[4].match(initDurationRegex)[1]
   }
   const logDetails = extractLogDetails(message)
-
-  return {
-    ...logDetails,
-    message,
-    duration,
-    billedDuration,
-    memorySize,
-    maxMemoryUsed,
-    ...initDuration,
-    ...rest
+  if (logDetails === message) {
+    return {
+      message,
+      duration,
+      billedDuration,
+      memorySize,
+      maxMemoryUsed,
+      ...initDuration,
+      ...rest
+    }
+  } else {
+    return {
+      ...logDetails,
+      duration,
+      billedDuration,
+      memorySize,
+      maxMemoryUsed,
+      ...initDuration,
+      ...rest
+    }
   }
 }
 


### PR DESCRIPTION
I added a regex to parse the kind of logs the user is asking about. 

They are logs in the syslog format, vercel also provides an option to log in json format, which probably would be parsed correctly.

The regex assumes the same format the user reported, if the log doesn't match that format, it won't be parsed and it will default to the behavior we had until now