### PR TITLE
qos & retain attr in config file for output-mqtt plugin

### DIFF
--- a/config/example.yml
+++ b/config/example.yml
@@ -149,7 +149,7 @@ input:
   #  url: mqtt://test.mosquitto.org
   #  # see connect options: https://www.npmjs.com/package/mqtt#connect
   #  connectOptions: 
-  #    userName: nobody 
+  #    username: nobody
   #    password: secret
   #  topics: 
   #    - log-messages
@@ -824,6 +824,8 @@ output:
   #  module: output-mqtt
   #  url: mqtt://test.mosquitto.org
   #  topic: sensor-data
+  #  qos: 2
+  #  retain: false
   #  debug: false
   #  # optional filter settings matching data field with regular expressions
   #  filter: 
@@ -833,6 +835,8 @@ output:
   #  module: output-mqtt
   #  url: mqtt://test.mosquitto.org
   #  topic: log-data
+  #  qos: 2
+  #  retain: false
   #  debug: false
   #  filter: 
   #    field: logSource

--- a/config/examples/mqtt-output.yml
+++ b/config/examples/mqtt-output.yml
@@ -7,13 +7,15 @@ output:
     url: mqtt://test.mosquitto.org
     # see https://www.npmjs.com/package/mqtt#connect
     #connectOptions:
-    #  userName: nobody 
+    #  username: nobody
     #  password: secret
-    #  keepAlive: 60 
+    #  keepalive: 60
     #  wsOptions: 
     #    port: 9999
     #    host: localhost
     topic: sensor-data
+    qos: 2
+    retain: false
     debug: false
     # optional filter settings matching data field with regular expressions
     filter: 

--- a/lib/plugins/output/mqtt.js
+++ b/lib/plugins/output/mqtt.js
@@ -5,14 +5,16 @@ var consoleLogger = require('../../util/logger.js')
 
 /** example configuration
   output:
-    module: mqtt
+    module: output-mqtt
     url: mqtt://127.0.0.1:1883
     topic: all_events
+    qos: 2
+    retain: false
     # see https://www.npmjs.com/package/mqtt#connect options
     connectOptions:
-      userName: nobody
+      username: nobody
       password: secret
-      keepAlive: 60
+      keepalive: 60
       wsOptions:
         port: 9999
         host: localhost
@@ -59,7 +61,10 @@ OutputMqtt.prototype.eventHandler = function (data, context) {
       if (this.config.debug === true) {
         consoleLogger.log('mqtt publish -t ' + topic + ' -m ' + msg)
       }
-      return this.client.publish(topic, msg)
+      return this.client.publish(topic, msg, {
+        qos: this.config.qos || 0,
+        retain: this.config.retain || false
+      })
     } else {
       if (this.config.debug === true) {
         consoleLogger.log(
@@ -72,7 +77,10 @@ OutputMqtt.prototype.eventHandler = function (data, context) {
     if (this.config.debug === true) {
       consoleLogger.log('mqtt pub -t ' + topic + ' -m ' + msg)
     }
-    return this.client.publish(topic, safeStringify(data))
+    return this.client.publish(topic, safeStringify(data), {
+      qos: this.config.qos || 0,
+      retain: this.config.retain || false
+    })
   }
 }
 

--- a/lib/plugins/output/mqtt.js
+++ b/lib/plugins/output/mqtt.js
@@ -38,6 +38,7 @@ module.exports = OutputMqtt
 OutputMqtt.prototype.eventHandler = function (data, context) {
   var msg = safeStringify(data)
   var topic = this.config.topic
+  const { qos = 0, retain = false } = this.config
   if (this.config.dynamicTopic !== undefined) {
     topic = eval(this.config.dynamicTopic)
     consoleLogger.log('Topic ' + topic)
@@ -61,10 +62,7 @@ OutputMqtt.prototype.eventHandler = function (data, context) {
       if (this.config.debug === true) {
         consoleLogger.log('mqtt publish -t ' + topic + ' -m ' + msg)
       }
-      return this.client.publish(topic, msg, {
-        qos: this.config.qos || 0,
-        retain: this.config.retain || false
-      })
+      return this.client.publish(topic, msg, { qos, retain })
     } else {
       if (this.config.debug === true) {
         consoleLogger.log(
@@ -77,10 +75,7 @@ OutputMqtt.prototype.eventHandler = function (data, context) {
     if (this.config.debug === true) {
       consoleLogger.log('mqtt pub -t ' + topic + ' -m ' + msg)
     }
-    return this.client.publish(topic, safeStringify(data), {
-      qos: this.config.qos || 0,
-      retain: this.config.retain || false
-    })
+    return this.client.publish(topic, msg, { qos, retain })
   }
 }
 


### PR DESCRIPTION
- Add `qos` & `retain` for _output-mqtt_ plugin in config file, keeping default values.
- Based on [mqtt.js doc](https://github.com/mqttjs/MQTT.js/blob/3c1f3351639628f6bce1e4dcaac6bfe82ec036f6/README.md?plain=1#L414), examples adjusted.

Fixes #264